### PR TITLE
fix: Verify mint for all token accounts

### DIFF
--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -51,6 +51,7 @@ pub mod solana_spl_swaps {
         token::transfer(token_transfer_context, swap_amount)?;
 
         *ctx.accounts.swap_data = SwapAccount {
+            mint: mint.key(),
             initiator: initiator.key(),
             expiry_slot: Clock::get()?.slot + expires_in_slots,
             redeemer,
@@ -204,6 +205,8 @@ pub mod solana_spl_swaps {
 #[account]
 #[derive(InitSpace)]
 pub struct SwapAccount {
+    /// The mint used in this swap
+    pub mint: Pubkey,
     /// The exact slot after which (non-instant) refunds are allowed
     pub expiry_slot: u64,
     /// The initiator of the atomic swap
@@ -316,11 +319,11 @@ pub struct Redeem<'info> {
     pub swap_data: Account<'info, SwapAccount>,
 
     /// A token account controlled by the program, escrowing the tokens for this atomic swap
-    #[account(mut, token::authority = identity_pda)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = identity_pda)]
     pub token_vault: Account<'info, TokenAccount>,
 
     /// CHECK: The token account of the redeemer
-    #[account(mut, token::authority = swap_data.redeemer)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = swap_data.redeemer)]
     pub redeemer_token_account: Account<'info, TokenAccount>,
 
     /// CHECK: Sponsor's address for refunding PDA rent
@@ -347,11 +350,11 @@ pub struct Refund<'info> {
     pub swap_data: Account<'info, SwapAccount>,
 
     /// A token account controlled by the program, escrowing the tokens for this atomic swap
-    #[account(mut, token::authority = identity_pda)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = identity_pda)]
     pub token_vault: Account<'info, TokenAccount>,
 
     /// CHECK: The token account of the initiator
-    #[account(mut, token::authority = swap_data.initiator)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = swap_data.initiator)]
     pub initiator_token_account: Account<'info, TokenAccount>,
 
     /// CHECK: Sponsor's address for refunding PDA rent
@@ -378,11 +381,11 @@ pub struct InstantRefund<'info> {
     pub swap_data: Account<'info, SwapAccount>,
 
     /// A token account controlled by the program, escrowing the tokens for this atomic swap
-    #[account(mut, token::authority = identity_pda)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = identity_pda)]
     pub token_vault: Account<'info, TokenAccount>,
 
     /// CHECK: The token account of the initiator
-    #[account(mut, token::authority = swap_data.initiator)]
+    #[account(mut, token::mint = swap_data.mint, token::authority = swap_data.initiator)]
     pub initiator_token_account: Account<'info, TokenAccount>,
 
     /// The redeemer of the atomic swap. They must sign this transaction.


### PR DESCRIPTION
The current checks for redeem/refund instructions only verify:
- Does the token vault belong to the program?
- Does the provided token accounts belong to the right people

The lack of checking mint allows for a malicious user to provide a valid token vault and a valid token
account for a mint that they did not initiate with.

Example scenario:
1. User A initiates with Mint M1 and User B as redeemer.
2. A's funds of mint M1 are stored in token vault T1.
3. User C initiates with Mint M2 and User D as redeemer.
4. C's funds of mint M2 are stored in token vault T2.
5. D "redeems" by specifying
  - token vault T1 instead of T2
  - D's token account of mint M1 instead of M2

Effectively stealing A's funds from token vault T1.

Thus store mint in the swap account and use it to verify the mints
of all the token accounts.