### PR TITLE
UDA logic added to HTLC

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,6 @@
+# Notes  
+- swap_account -> Order (PDA)  
+- swap_token_account -> will be constant for a particular token  
+  - identity_pda is the token authority for swap_token_accounts  
+  - cannot be handled from any other solana program  
+- 

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -231,9 +231,9 @@ pub mod solana_spl_swaps {
     // ============ UDA Logic ============
 
     /// Create an SPL token Unique Deposit Address
-    /// 
+    ///
     /// Creates a UDA for SPL token transfers with a token vault and destination data.
-    /// 
+    ///
     /// # Arguments
     /// * `ctx` - Context containing all required accounts including token vault
     /// * `mint` - SPL token mint address
@@ -243,17 +243,16 @@ pub mod solana_spl_swaps {
     /// * `secret_hash` - Hash of the secret required for redemption
     /// * `amount` - Amount of tokens to lock in the vault
     /// * `destination_data` - Cross-chain routing data
-    /// 
+    ///
     /// # Returns
     /// * `Result<Pubkey>` - The token vault address where tokens should be sent
-    /// 
+    ///
     /// # Errors
-    /// * `ZeroAmount` - If amount is zero
     /// * `SameAddress` - If refund_address equals redeemer
     /// * `InvalidAddress` - If any address is the default pubkey
     /// * `InvalidMint` - If mint is the default pubkey
-    /// * `InvalidHTLCProgram` - If HTLC program is not registered for this mint
     /// * `InvalidSecretHash` - If secret hash is all zeros or destination hash mismatch
+    /// * `DestinationHashMismatchComputedHash` - If destination_hash doesn't match sha256(destination_data)
     pub fn create_uda_spl(
         ctx: Context<CreateSPLUDA>,
         mint: Pubkey,
@@ -263,20 +262,29 @@ pub mod solana_spl_swaps {
         secret_hash: [u8; 32],
         amount: u64,
         destination_data: Vec<u8>,
-        destination_hash: [u8; 32]
+        destination_hash: [u8; 32],
     ) -> Result<Pubkey> {
         require!(refund_address != redeemer, UDAError::SameAddress);
-        require!(refund_address != Pubkey::default(), UDAError::InvalidAddress);
+        require!(
+            refund_address != Pubkey::default(),
+            UDAError::InvalidAddress
+        );
         require!(redeemer != Pubkey::default(), UDAError::InvalidAddress);
         require!(mint != Pubkey::default(), UDAError::InvalidMint);
         require!(secret_hash != [0u8; 32], UDAError::InvalidSecretHash);
 
         let computed_hash = hash::hash(&destination_data).to_bytes();
-        require!(destination_hash == computed_hash, UDAError::DestinationHashMismatchComputedHash);
+        require!(
+            destination_hash == computed_hash,
+            UDAError::DestinationHashMismatchComputedHash
+        );
 
         let uda = &mut ctx.accounts.uda;
         require!(uda.key() != redeemer, UDAError::SameAddress);
-        require!(ctx.accounts.mint_account.key() == mint, UDAError::InvalidMint);
+        require!(
+            ctx.accounts.mint_account.key() == mint,
+            UDAError::InvalidMint
+        );
 
         uda.mint = mint;
         uda.refund_address = refund_address;
@@ -303,31 +311,28 @@ pub mod solana_spl_swaps {
     }
 
     /// Initiate Hash Time Lock Contract for an SPL token UDA
-    /// 
+    ///
     /// Creates and executes an HTLC instruction on the registered HTLC program
-    /// for SPL token transfers. After initiation, transfers any excess tokens to 
+    /// for SPL token transfers. After initiation, transfers any excess tokens to
     /// the refund token account and closes the UDA account, returning rent to the sponsor.
     /// The stored destination_data is passed to the HTLC program for cross-chain routing.
-    /// 
+    ///
     /// # Arguments
     /// * `ctx` - Context containing UDA, token accounts, HTLC program, and cleanup accounts
-    /// 
+    ///
     /// # Returns
     /// * `Result<()>` - Success or error
-    /// 
+    ///
     /// # Errors
-    /// * `InvalidState` - If UDA is not in Created state
-    /// * `InvalidTimelock` - If timelock is zero
-    /// * `InvalidHTLCProgram` - If HTLC program doesn't match UDA registration
     /// * `InvalidMint` - If token mint doesn't match UDA mint
     /// * `InsufficientFunds` - If token vault doesn't have enough tokens
     pub fn initiate_uda(ctx: Context<InitiateUDA>) -> Result<()> {
         let uda = &mut ctx.accounts.uda;
 
         require!(
-            ctx.accounts.mint_account.key() == uda.mint && 
-            ctx.accounts.uda_token_vault.mint == uda.mint && 
-            ctx.accounts.refund_token_account.key() == uda.mint,
+            ctx.accounts.mint_account.key() == uda.mint
+                && ctx.accounts.uda_token_vault.mint == uda.mint
+                && ctx.accounts.refund_token_account.key() == uda.mint,
             UDAError::InvalidMint
         );
 
@@ -348,9 +353,9 @@ pub mod solana_spl_swaps {
         let transfer_ctx = CpiContext::new(
             ctx.accounts.token_program.to_account_info(),
             token::Transfer {
-                from: ctx.accounts.uda_token_vault.to_account_info(),      // UDA staging vault
-                to: ctx.accounts.token_vault.to_account_info(),            // HTLC vault
-                authority: uda.to_account_info(),                          // UDA PDA authority
+                from: ctx.accounts.uda_token_vault.to_account_info(), // UDA staging vault
+                to: ctx.accounts.token_vault.to_account_info(),       // HTLC vault
+                authority: uda.to_account_info(),                     // UDA PDA authority
             },
         );
         token::transfer(transfer_ctx, amount)?;
@@ -420,12 +425,12 @@ pub struct SPLUDA {
     pub secret_hash: [u8; 32],
     pub amount: u64,
     pub vault_address: Pubkey,
-    pub created_at: u64,        // Slot when UDA was created (0 = not created, >0 = created)
+    pub created_at: u64, // Slot when UDA was created (0 = not created, >0 = created)
     pub rent_sponsor: Pubkey, // Who paid for UDA creation (gets rent back)
-    #[max_len(1024)]  // Large limit - user pays for storage
+    #[max_len(1024)] // Large limit - user pays for storage
     pub destination_data: Vec<u8>, // Destination data for cross-chain/routing purposes
-    pub destination_hash: [u8; 32],  // SHA256 hash of destination_data for PDA seeds
-    pub identity_pda_bump: u8
+    pub destination_hash: [u8; 32], // SHA256 hash of destination_data for PDA seeds
+    pub identity_pda_bump: u8,
 }
 
 /// Stores the state information of the atomic swap on-chain
@@ -874,47 +879,20 @@ pub enum SwapError {
 
 #[error_code]
 pub enum UDAError {
-    #[msg("Invalid timelock - must be greater than zero")]
-    InvalidTimelock,
-
-    #[msg("Amount cannot be zero")]
-    ZeroAmount,
-
     #[msg("Invalid address - cannot be zero address")]
     InvalidAddress,
 
     #[msg("Refund address and redeemer cannot be the same")]
     SameAddress,
 
-    #[msg("Invalid UDA state for this operation")]
-    InvalidState,
-
-    #[msg("UDA has expired")]
-    Expired,
-
     #[msg("Insufficient funds in UDA")]
     InsufficientFunds,
-
-    #[msg("Invalid refund address")]
-    InvalidRefundAddress,
-
-    #[msg("Invalid HTLC program address")]
-    InvalidHTLCProgram,
 
     #[msg("Invalid secret hash - cannot be zero")]
     InvalidSecretHash,
 
     #[msg("Invalid mint address")]
     InvalidMint,
-
-    #[msg("Unauthorized operation")]
-    Unauthorized,
-    
-    #[msg("Token already registered")]
-    TokenAlreadyRegistered,
-
-    #[msg("Invalid destination data provided")]
-    InvalidDestinationData,
 
     #[msg("Destination hash does not match destination data")]
     DestinationHashMismatchComputedHash,

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -48,8 +48,12 @@ pub mod solana_spl_swaps {
         );
         token::transfer(token_transfer_context, swap_amount)?;
 
+        let expiry_slot = Clock::get()?
+            .slot
+            .checked_add(timelock)
+            .expect("timelock should not cause an overflow");
         *ctx.accounts.swap_data = SwapAccount {
-            expiry_slot: Clock::get()?.slot + timelock,
+            expiry_slot,
             bump: ctx.bumps.swap_data,
             identity_pda_bump: ctx.bumps.identity_pda,
             rent_sponsor: rent_sponsor.key(),

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -326,7 +326,9 @@ pub mod solana_spl_swaps {
         let uda = &mut ctx.accounts.uda;
 
         require!(
-            ctx.accounts.mint_account.key() == uda.mint || ctx.accounts.token_vault.mint == uda.mint,
+            ctx.accounts.mint_account.key() == uda.mint && 
+            ctx.accounts.token_vault.mint == uda.mint && 
+            ctx.accounts.refund_token_account.key() == uda.mint,
             UDAError::InvalidMint
         );
 
@@ -357,15 +359,14 @@ pub mod solana_spl_swaps {
         ]];
 
         // Transfer the exact swap amount from the UDA's staging vault into the HTLC vault
-        let transfer_ctx = CpiContext::new_with_signer(
+        let transfer_ctx = CpiContext::new(
             ctx.accounts.token_program.to_account_info(),
             token::Transfer {
                 from: ctx.accounts.token_vault.to_account_info(),      // UDA staging vault
                 to: ctx.accounts.spl_token_vault.to_account_info(),    // HTLC vault
                 authority: uda.to_account_info(),                      // UDA PDA authority
             },
-            uda_signer_seeds,
-        );
+        ); // @audit-ok
         token::transfer(transfer_ctx, amount)?;
 
         let expiry_slot = Clock::get()?
@@ -392,14 +393,13 @@ pub mod solana_spl_swaps {
         ctx.accounts.token_vault.reload()?;
         let residual = ctx.accounts.token_vault.amount;
         if residual > 0 {
-            let residual_ctx = CpiContext::new_with_signer(
+            let residual_ctx = CpiContext::new(
                 ctx.accounts.token_program.to_account_info(),
                 token::Transfer {
                     from: ctx.accounts.token_vault.to_account_info(),
                     to: ctx.accounts.refund_token_account.to_account_info(),
                     authority: uda.to_account_info(),
                 },
-                uda_signer_seeds,
             );
             token::transfer(residual_ctx, residual)?;
         }
@@ -408,6 +408,16 @@ pub mod solana_spl_swaps {
             uda_address: uda.key(),
             swap_amount: uda.amount,
             timelock: uda.timelock,
+        });
+
+        emit!(Initiated {
+            mint: uda.mint,
+            redeemer,
+            refundee: refund_address,
+            secret_hash,
+            swap_amount: amount,
+            timelock,
+            destination_data: Some(uda.destination_data.clone())
         });
 
         Ok(())
@@ -757,13 +767,7 @@ pub struct InitiateUDA<'info> {
     pub rent_sponsor: Signer<'info>,
 
     /// Identity PDA reused from standard initiate flow (created once, empty seed array)
-    #[account(
-        init_if_needed,
-        payer = rent_sponsor,
-        seeds = [],
-        bump,
-        space = ANCHOR_DISCRIMINATOR,
-    )]
+    #[account(seeds = [], bump = swap_data.identity_pda_bump)]
     pub identity_pda: AccountInfo<'info>,
 
     /// Swap data account (created here to mirror standard initiate flow) storing absolute timelock
@@ -771,6 +775,7 @@ pub struct InitiateUDA<'info> {
         init,
         payer = rent_sponsor,
         seeds = [
+            uda.mint.as_ref(),
             uda.redeemer.as_ref(),
             uda.refund_address.as_ref(),
             &uda.secret_hash,

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -269,10 +269,7 @@ pub struct SwapAccount {
 #[instruction(redeemer: Pubkey, refundee: Pubkey, secret_hash: [u8; 32], swap_amount: u64, timelock: u64)]
 pub struct Initiate<'info> {
     /// CHECK: Program-derived address used solely as signing authority (no data allocation)
-    #[account(
-        seeds = [],
-        bump,
-    )]
+    #[account(seeds = [], bump)]
     pub identity_pda: AccountInfo<'info>,
 
     /// A PDA that maintains the on-chain state of the atomic swap throughout its lifecycle.
@@ -282,9 +279,9 @@ pub struct Initiate<'info> {
         init,
         payer = rent_sponsor,
         seeds = [
+            mint.key().as_ref(),
             redeemer.as_ref(),
             refundee.as_ref(),
-            mint.key().as_ref(),
             &secret_hash,
             &swap_amount.to_le_bytes(),
             &timelock.to_le_bytes(),
@@ -347,9 +344,9 @@ pub struct Redeem<'info> {
     #[account(
         mut,
         seeds = [
+            swap_data.mint.as_ref(),
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
-            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -385,9 +382,9 @@ pub struct Refund<'info> {
     #[account(
         mut,
         seeds = [
+            swap_data.mint.as_ref(),
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
-            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -423,9 +420,9 @@ pub struct InstantRefund<'info> {
     #[account(
         mut,
         seeds = [
+            swap_data.mint.as_ref(),
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
-            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -268,16 +268,10 @@ pub struct SwapAccount {
 // Refer: https://www.anchor-lang.com/docs/references/account-constraints#instruction-attribute
 #[instruction(redeemer: Pubkey, refundee: Pubkey, secret_hash: [u8; 32], swap_amount: u64, timelock: u64)]
 pub struct Initiate<'info> {
-    /// CHECK: A permanent PDA that represents this swap program for authorizing
-    /// the token transfers of the `token_vault` PDA.  
-    /// This PDA will be created during the first most invocation of the `initiate()` function
-    /// using the `init_if_needed` attribute, and be reused for all succeeding instructions.
+    /// CHECK: Program-derived address used solely as signing authority (no data allocation)
     #[account(
-        init_if_needed,
-        payer = rent_sponsor,
         seeds = [],
         bump,
-        space = ANCHOR_DISCRIMINATOR,
     )]
     pub identity_pda: AccountInfo<'info>,
 
@@ -290,6 +284,7 @@ pub struct Initiate<'info> {
         seeds = [
             redeemer.as_ref(),
             refundee.as_ref(),
+            mint.key().as_ref(),
             &secret_hash,
             &swap_amount.to_le_bytes(),
             &timelock.to_le_bytes(),
@@ -354,6 +349,7 @@ pub struct Redeem<'info> {
         seeds = [
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
+            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -391,6 +387,7 @@ pub struct Refund<'info> {
         seeds = [
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
+            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -428,6 +425,7 @@ pub struct InstantRefund<'info> {
         seeds = [
             swap_data.redeemer.as_ref(),
             swap_data.refundee.as_ref(),
+            swap_data.mint.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -49,9 +49,11 @@ pub mod solana_spl_swaps {
 
         *ctx.accounts.swap_data = SwapAccount {
             expiry_slot: Clock::get()?.slot + timelock,
+            bump: ctx.bumps.swap_data,
             identity_pda_bump: ctx.bumps.identity_pda,
             rent_sponsor: rent_sponsor.key(),
             initiator: initiator.key(),
+            mint: mint.key(),
             redeemer,
             secret_hash,
             swap_amount,
@@ -84,8 +86,11 @@ pub mod solana_spl_swaps {
         let SwapAccount {
             identity_pda_bump,
             initiator,
+            mint,
+            redeemer,
             secret_hash,
             swap_amount,
+            timelock,
             ..
         } = **swap_data;
 
@@ -106,7 +111,14 @@ pub mod solana_spl_swaps {
         .with_signer(pda_seeds);
         token::transfer(token_transfer_context, swap_amount)?;
 
-        emit!(Redeemed { initiator, secret });
+        emit!(Redeemed {
+            initiator,
+            mint,
+            redeemer,
+            secret,
+            swap_amount,
+            timelock,
+        });
 
         Ok(())
     }
@@ -126,9 +138,12 @@ pub mod solana_spl_swaps {
         let SwapAccount {
             identity_pda_bump,
             initiator,
+            mint,
+            redeemer,
             expiry_slot,
             secret_hash,
             swap_amount,
+            timelock,
             ..
         } = **swap_data;
 
@@ -151,7 +166,11 @@ pub mod solana_spl_swaps {
 
         emit!(Refunded {
             initiator,
+            mint,
+            redeemer,
             secret_hash,
+            swap_amount,
+            timelock,
         });
 
         Ok(())
@@ -172,8 +191,11 @@ pub mod solana_spl_swaps {
         let SwapAccount {
             identity_pda_bump,
             initiator,
+            mint,
+            redeemer,
             secret_hash,
             swap_amount,
+            timelock,
             ..
         } = **swap_data;
 
@@ -191,7 +213,11 @@ pub mod solana_spl_swaps {
 
         emit!(InstantRefunded {
             initiator,
-            secret_hash
+            mint,
+            redeemer,
+            secret_hash,
+            swap_amount,
+            timelock,
         });
 
         Ok(())
@@ -202,6 +228,9 @@ pub mod solana_spl_swaps {
 #[account]
 #[derive(InitSpace)]
 pub struct SwapAccount {
+    /// The bump that derived this PDA.
+    /// Storing this makes later verifications less expensive.
+    pub bump: u8,
     /// The exact slot after which (non-instant) refunds are allowed
     pub expiry_slot: u64,
     /// The bump associated with the identity pda.
@@ -213,6 +242,8 @@ pub struct SwapAccount {
 
     /// The initiator of the atomic swap
     pub initiator: Pubkey,
+    /// The mint for this atomic swap
+    pub mint: Pubkey,
     /// The redeemer of the atomic swap
     pub redeemer: Pubkey,
     /// The secret hash associated with the atomic swap
@@ -246,14 +277,19 @@ pub struct Initiate<'info> {
     )]
     pub identity_pda: AccountInfo<'info>,
 
-    /// A PDA that maintains the on-chain state of the atomic swap throughout its lifecycle.  
-    /// The choice of seeds ensure that any swap with equal `initiator` and
-    /// `secret_hash` wont be created until an existing one completes.  
+    /// A PDA that maintains the on-chain state of the atomic swap throughout its lifecycle.
+    /// The choice of seeds is to make the already expensive possibility of frontrunning, more expensive.
     /// This PDA will be deleted upon completion of the swap.
     #[account(
         init,
         payer = rent_sponsor,
-        seeds = [initiator.key().as_ref(), &secret_hash],
+        seeds = [
+            initiator.key().as_ref(),
+            redeemer.as_ref(),
+            &secret_hash,
+            &swap_amount.to_le_bytes(),
+            &timelock.to_le_bytes(),
+        ],
         bump,
         space = ANCHOR_DISCRIMINATOR + SwapAccount::INIT_SPACE,
     )]
@@ -310,8 +346,14 @@ pub struct Redeem<'info> {
     /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
-        seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
-        bump,
+        seeds = [
+            swap_data.initiator.key().as_ref(),
+            swap_data.redeemer.as_ref(),
+            &swap_data.secret_hash,
+            &swap_data.swap_amount.to_le_bytes(),
+            &swap_data.timelock.to_le_bytes(),
+        ],
+        bump = swap_data.bump,
         close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
@@ -341,8 +383,14 @@ pub struct Refund<'info> {
     /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
-        seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
-        bump,
+        seeds = [
+            swap_data.initiator.key().as_ref(),
+            swap_data.redeemer.as_ref(),
+            &swap_data.secret_hash,
+            &swap_data.swap_amount.to_le_bytes(),
+            &swap_data.timelock.to_le_bytes(),
+        ],
+        bump = swap_data.bump,
         close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
@@ -372,8 +420,14 @@ pub struct InstantRefund<'info> {
     /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
-        seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
-        bump,
+        seeds = [
+            swap_data.initiator.key().as_ref(),
+            swap_data.redeemer.as_ref(),
+            &swap_data.secret_hash,
+            &swap_data.swap_amount.to_le_bytes(),
+            &swap_data.timelock.to_le_bytes(),
+        ],
+        bump = swap_data.bump,
         close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
@@ -400,15 +454,15 @@ pub struct InstantRefund<'info> {
 /// Represents the initiated state of the swap where the initiator has deposited funds into the vault
 #[event]
 pub struct Initiated {
+    pub initiator: Pubkey,
+    pub mint: Pubkey,
+    pub redeemer: Pubkey,
+    pub secret_hash: [u8; 32],
     /// The quantity of tokens transferred through this atomic swap in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals will be represented as 1,000,000.
     pub swap_amount: u64,
     /// `timelock` represents the number of slots after which (non-instant) refunds are allowed
     pub timelock: u64,
-    pub initiator: Pubkey,
-    pub mint: Pubkey,
-    pub redeemer: Pubkey,
-    pub secret_hash: [u8; 32],
     /// Information regarding the destination chain in the atomic swap
     pub destination_data: Option<Vec<u8>>,
 }
@@ -416,20 +470,32 @@ pub struct Initiated {
 #[event]
 pub struct Redeemed {
     pub initiator: Pubkey,
+    pub mint: Pubkey,
+    pub redeemer: Pubkey,
     pub secret: [u8; 32],
+    pub swap_amount: u64,
+    pub timelock: u64,
 }
 /// Represents the refund state of the swap, where the initiator has withdrawn funds from the vault past expiry
 #[event]
 pub struct Refunded {
     pub initiator: Pubkey,
+    pub mint: Pubkey,
+    pub redeemer: Pubkey,
     pub secret_hash: [u8; 32],
+    pub swap_amount: u64,
+    pub timelock: u64,
 }
 /// Represents the instant refund state of the swap, where the initiator has withdrawn funds the vault
 /// with the redeemer's consent
 #[event]
 pub struct InstantRefunded {
     pub initiator: Pubkey,
+    pub mint: Pubkey,
+    pub redeemer: Pubkey,
     pub secret_hash: [u8; 32],
+    pub swap_amount: u64,
+    pub timelock: u64,
 }
 
 #[error_code]

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -253,50 +253,37 @@ pub mod solana_spl_swaps {
     /// * `InvalidMint` - If mint is the default pubkey
     /// * `InvalidSecretHash` - If secret hash is all zeros or destination hash mismatch
     /// * `DestinationHashMismatchComputedHash` - If destination_hash doesn't match sha256(destination_data)
-    pub fn create_uda_spl(
+    pub fn create_spl_uda(
         ctx: Context<CreateSPLUDA>,
-        mint: Pubkey,
-        refund_address: Pubkey,
-        redeemer: Pubkey,
-        timelock: u64,
-        secret_hash: [u8; 32],
-        amount: u64,
-        destination_data: Vec<u8>,
-        destination_hash: [u8; 32],
+        params: CreateSPLUDAParams,
     ) -> Result<Pubkey> {
-        require!(refund_address != redeemer, UDAError::SameAddress);
+        require!(params.refund_address != params.redeemer, UDAError::SameAddress);
         require!(
-            refund_address != Pubkey::default(),
+            params.refund_address != Pubkey::default(),
             UDAError::InvalidAddress
         );
-        require!(redeemer != Pubkey::default(), UDAError::InvalidAddress);
-        require!(mint != Pubkey::default(), UDAError::InvalidMint);
-        require!(secret_hash != [0u8; 32], UDAError::InvalidSecretHash);
+        require!(params.redeemer != Pubkey::default(), UDAError::InvalidAddress);
+        require!(params.secret_hash != [0u8; 32], UDAError::InvalidSecretHash);
 
-        let computed_hash = hash::hash(&destination_data).to_bytes();
+        let computed_hash = hash::hash(&params.destination_data).to_bytes();
         require!(
-            destination_hash == computed_hash,
+            params.destination_hash == computed_hash,
             UDAError::DestinationHashMismatchComputedHash
         );
 
         let uda = &mut ctx.accounts.uda;
-        require!(uda.key() != redeemer, UDAError::SameAddress);
-        require!(
-            ctx.accounts.mint_account.key() == mint,
-            UDAError::InvalidMint
-        );
+        require!(uda.key() != params.redeemer, UDAError::SameAddress);
 
-        uda.mint = mint;
-        uda.refund_address = refund_address;
-        uda.redeemer = redeemer;
-        uda.timelock = timelock;
-        uda.secret_hash = secret_hash;
-        uda.amount = amount;
+        uda.mint = ctx.accounts.mint_account.key();
+        uda.refund_address = params.refund_address;
+        uda.redeemer = params.redeemer;
+        uda.timelock = params.timelock;
+        uda.secret_hash = params.secret_hash;
+        uda.amount = params.amount;
         uda.vault_address = ctx.accounts.uda_token_vault.key();
-        uda.created_at = Clock::get()?.slot;
         uda.rent_sponsor = ctx.accounts.payer.key();
-        uda.destination_data = destination_data.clone();
-        uda.destination_hash = destination_hash;
+        uda.destination_data = params.destination_data.clone();
+        uda.destination_hash = params.destination_hash;
         uda.identity_pda_bump = ctx.bumps.identity_pda;
 
         emit!(SPLUDACreated {
@@ -425,7 +412,6 @@ pub struct SPLUDA {
     pub secret_hash: [u8; 32],
     pub amount: u64,
     pub vault_address: Pubkey,
-    pub created_at: u64, // Slot when UDA was created (0 = not created, >0 = created)
     pub rent_sponsor: Pubkey, // Who paid for UDA creation (gets rent back)
     #[max_len(1024)] // Large limit - user pays for storage
     pub destination_data: Vec<u8>, // Destination data for cross-chain/routing purposes
@@ -655,29 +641,34 @@ pub struct InstantRefund<'info> {
     pub token_program: Program<'info, Token>,
 }
 
+// Structured instruction args for creating an SPL UDA. Using a single struct
+// prevents callers from accidentally passing parameters in the wrong order.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct CreateSPLUDAParams {
+    pub refund_address: Pubkey,
+    pub redeemer: Pubkey,
+    pub timelock: u64,
+    pub secret_hash: [u8; 32],
+    pub amount: u64,
+    pub destination_data: Vec<u8>,
+    pub destination_hash: [u8; 32],
+}
+
 #[derive(Accounts)]
-#[instruction(
-    mint: Pubkey,
-    refund_address: Pubkey,
-    redeemer: Pubkey,
-    timelock: u64,
-    secret_hash: [u8; 32],
-    amount: u64,
-    destination_hash: [u8; 32]
-)]
+#[instruction(params: CreateSPLUDAParams)]
 pub struct CreateSPLUDA<'info> {
     #[account(
         init,
         payer = payer,
         seeds = [
             b"spl_uda",
-            mint.as_ref(),
-            refund_address.as_ref(),
-            redeemer.as_ref(),
-            &secret_hash,
-            &amount.to_le_bytes(),
-            &timelock.to_le_bytes(),
-            &destination_hash
+            mint_account.key().as_ref(),
+            params.refund_address.as_ref(),
+            params.redeemer.as_ref(),
+            &params.secret_hash,
+            &params.amount.to_le_bytes(),
+            &params.timelock.to_le_bytes(),
+            &params.destination_hash
         ],
         bump,
         space = SPLUDA::INIT_SPACE,
@@ -692,7 +683,6 @@ pub struct CreateSPLUDA<'info> {
         payer = payer,
         seeds = [
             b"token_vault",
-            mint.key().as_ref(),
             uda.key().as_ref()
         ],
         bump,

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -227,6 +227,211 @@ pub mod solana_spl_swaps {
 
         Ok(())
     }
+
+    // ============ UDA Logic ============
+
+    /// Create an SPL token Unique Deposit Address
+    /// 
+    /// Creates a UDA for SPL token transfers with a token vault and destination data.
+    /// 
+    /// # Arguments
+    /// * `ctx` - Context containing all required accounts including token vault
+    /// * `mint` - SPL token mint address
+    /// * `refund_address` - Address to receive tokens if the UDA expires
+    /// * `redeemer` - Address authorized to redeem the UDA
+    /// * `timelock` - Slot number when the UDA expires
+    /// * `secret_hash` - Hash of the secret required for redemption
+    /// * `amount` - Amount of tokens to lock in the vault
+    /// * `destination_data` - Cross-chain routing data
+    /// 
+    /// # Returns
+    /// * `Result<Pubkey>` - The token vault address where tokens should be sent
+    /// 
+    /// # Errors
+    /// * `ZeroAmount` - If amount is zero
+    /// * `SameAddress` - If refund_address equals redeemer
+    /// * `InvalidAddress` - If any address is the default pubkey
+    /// * `InvalidMint` - If mint is the default pubkey
+    /// * `InvalidHTLCProgram` - If HTLC program is not registered for this mint
+    /// * `InvalidSecretHash` - If secret hash is all zeros or destination hash mismatch
+    pub fn create_uda_spl(
+        ctx: Context<CreateSPLUDA>,
+        mint: Pubkey,
+        refund_address: Pubkey,
+        redeemer: Pubkey,
+        timelock: u64,
+        secret_hash: [u8; 32],
+        amount: u64,
+        destination_data: Vec<u8>,
+        destination_hash: [u8; 32]
+    ) -> Result<Pubkey> {
+        require!(amount > 0, UDAError::ZeroAmount);
+        require!(refund_address != redeemer, UDAError::SameAddress);
+        require!(refund_address != Pubkey::default(), UDAError::InvalidAddress);
+        require!(redeemer != Pubkey::default(), UDAError::InvalidAddress);
+        require!(mint != Pubkey::default(), UDAError::InvalidMint);
+        require!(secret_hash != [0u8; 32], UDAError::InvalidSecretHash);
+
+        let computed_hash = hash::hash(&destination_data).to_bytes();
+        require!(destination_hash == computed_hash, UDAError::DestinationHashMismatchComputedHash);
+
+        let uda = &mut ctx.accounts.uda;
+        require!(uda.key() != redeemer, UDAError::SameAddress);
+
+        uda.mint = mint;
+        uda.refund_address = refund_address;
+        uda.redeemer = redeemer;
+        uda.timelock = timelock;
+        uda.secret_hash = secret_hash;
+        uda.amount = amount;
+        uda.vault_address = ctx.accounts.token_vault.key();
+        uda.created_at = Clock::get()?.slot;
+        uda.rent_sponsor = ctx.accounts.payer.key();
+        uda.destination_data = destination_data.clone();
+        uda.destination_hash = destination_hash;
+
+        emit!(SPLUDACreated {
+            uda_address: uda.key(),
+            vault_address: ctx.accounts.token_vault.key(),
+            refund_address: uda.refund_address,
+            amount: uda.amount,
+            timelock: uda.timelock,
+        });
+
+        Ok(ctx.accounts.token_vault.key())
+    }
+
+    /// Initiate Hash Time Lock Contract for an SPL token UDA
+    /// 
+    /// Creates and executes an HTLC instruction on the registered HTLC program
+    /// for SPL token transfers. After initiation, transfers any excess tokens to 
+    /// the refund token account and closes the UDA account, returning rent to the sponsor.
+    /// The stored destination_data is passed to the HTLC program for cross-chain routing.
+    /// 
+    /// # Arguments
+    /// * `ctx` - Context containing UDA, token accounts, HTLC program, and cleanup accounts
+    /// 
+    /// # Returns
+    /// * `Result<()>` - Success or error
+    /// 
+    /// # Errors
+    /// * `InvalidState` - If UDA is not in Created state
+    /// * `InvalidTimelock` - If timelock is zero
+    /// * `InvalidHTLCProgram` - If HTLC program doesn't match UDA registration
+    /// * `InvalidMint` - If token mint doesn't match UDA mint
+    /// * `InsufficientFunds` - If token vault doesn't have enough tokens
+    pub fn initiate_htlc_spl(ctx: Context<InitiateHtlcSpl>) -> Result<()> {
+        let uda = &mut ctx.accounts.uda;
+
+        require!(uda.timelock > 0, UDAError::InvalidTimelock);
+
+        require!(
+            ctx.accounts.mint_account.key() == uda.mint,
+            UDAError::InvalidMint
+        );
+
+        require!(
+            ctx.accounts.token_vault.amount >= uda.amount,
+            UDAError::InsufficientFunds
+        );
+
+        let current_slot = Clock::get()?.slot;
+    // For UDA path we expect uda.timelock to already be an absolute slot (expiry)
+    if current_slot > uda.timelock { return err!(UDAError::Expired); }
+
+        // Store values we need before creating signer seeds
+        let mint = uda.mint;
+        let refund_address = uda.refund_address;
+        let redeemer = uda.redeemer;
+        let secret_hash = uda.secret_hash;
+        let amount = uda.amount;
+        let timelock = uda.timelock;
+        let destination_hash = uda.destination_hash;
+
+        // UDA signer seeds (authority over the pre-init vault holding initial funds)
+        let uda_signer_seeds: &[&[&[u8]]] = &[&[
+            b"spl_uda",
+            mint.as_ref(),
+            refund_address.as_ref(),
+            redeemer.as_ref(),
+            &secret_hash,
+            &amount.to_le_bytes(),
+            &timelock.to_le_bytes(),
+            &destination_hash,
+        ]];
+
+        // Transfer the exact swap amount from the UDA's staging vault into the uniquely derived HTLC vault
+        let transfer_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            token::Transfer {
+                from: ctx.accounts.token_vault.to_account_info(),      // UDA staging vault
+                to: ctx.accounts.spl_token_vault.to_account_info(),    // Per-UDA HTLC vault
+                authority: uda.to_account_info(),                      // UDA PDA authority
+            },
+            uda_signer_seeds,
+        );
+    token::transfer(transfer_ctx, amount)?;
+
+        // Initialize the swap data account (created in this instruction via Init constraint)
+        // For UDA path we store absolute timelock (same as expiry_slot) to keep seeds deterministic.
+        *ctx.accounts.swap_data = SwapAccount {
+            expiry_slot: timelock, // absolute expiry slot
+            bump: ctx.bumps.swap_data,
+            identity_pda_bump: ctx.bumps.identity_pda,
+            rent_sponsor: ctx.accounts.rent_sponsor.key(),
+            mint,
+            redeemer,
+            refundee: refund_address,
+            secret_hash,
+            swap_amount: amount,
+            timelock, // absolute (differs from standard initiate which stores relative)
+        };
+
+        // After moving the required amount, send any residual balance in the staging vault back to the refund address
+        ctx.accounts.token_vault.reload()?;
+        let residual = ctx.accounts.token_vault.amount;
+        if residual > 0 {
+            let residual_ctx = CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                token::Transfer {
+                    from: ctx.accounts.token_vault.to_account_info(),
+                    to: ctx.accounts.refund_token_account.to_account_info(),
+                    authority: uda.to_account_info(),
+                },
+                uda_signer_seeds,
+            );
+            token::transfer(residual_ctx, residual)?;
+        }
+
+        uda.initiated_at = Some(Clock::get()?.slot);
+
+        emit!(HTLCInitiated {
+            uda_address: uda.key(),
+            htlc_program: uda.htlc_program,
+            swap_amount: uda.amount,
+            timelock: uda.timelock,
+        });
+
+        Ok(())
+    }
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct SPLUDA {
+    pub mint: Pubkey,
+    pub refund_address: Pubkey,
+    pub redeemer: Pubkey,
+    pub timelock: u64,
+    pub secret_hash: [u8; 32],
+    pub amount: u64,
+    pub htlc_program: Pubkey,
+    pub vault_address: Pubkey,
+    pub created_at: u64,        // Slot when UDA was created (0 = not created, >0 = created)
+    pub rent_sponsor: Pubkey, // Who paid for UDA creation (gets rent back)
+    #[max_len(10240)]  // Large limit - user pays for storage
+    pub destination_data: Vec<u8>, // Destination data for cross-chain/routing purposes
+    pub destination_hash: [u8; 32],  // SHA256 hash of destination_data for PDA seeds
 }
 
 /// Stores the state information of the atomic swap on-chain
@@ -451,6 +656,153 @@ pub struct InstantRefund<'info> {
     pub token_program: Program<'info, Token>,
 }
 
+#[derive(Accounts)]
+#[instruction(
+    mint: Pubkey,
+    refund_address: Pubkey,
+    redeemer: Pubkey,
+    timelock: u64,
+    secret_hash: [u8; 32],
+    amount: u64,
+    destination_hash: [u8; 32]
+)]
+pub struct CreateSPLUDA<'info> {
+    #[account(
+        init,
+        payer = payer,
+        seeds = [
+            b"spl_uda",
+            mint.as_ref(),
+            refund_address.as_ref(),
+            redeemer.as_ref(),
+            &secret_hash,
+            &amount.to_le_bytes(),
+            &timelock.to_le_bytes(),
+            &destination_hash
+        ],
+        bump,
+        space = SPLUDA::INIT_SPACE,
+    )]
+    pub uda: Account<'info, SPLUDA>,
+
+    #[account(
+        init_if_needed,
+        payer = payer,
+        seeds = [
+            b"token_vault",
+            mint.key().as_ref(),
+            uda.key().as_ref()
+        ],
+        bump,
+        token::mint = mint_account,
+        token::authority = uda,
+    )]
+    pub token_vault: Account<'info, TokenAccount>,
+
+    pub mint_account: Account<'info, Mint>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct InitiateHtlcSpl<'info> {
+    #[account(
+        mut,
+        close = rent_sponsor,
+        seeds = [
+            b"spl_uda",
+            uda.mint.as_ref(),
+            uda.refund_address.as_ref(),
+            uda.redeemer.as_ref(),
+            &uda.secret_hash,
+            &uda.amount.to_le_bytes(),
+            &uda.timelock.to_le_bytes(),
+            uda.htlc_program.as_ref(),
+            &uda.destination_hash,
+        ],
+        bump,
+    )]
+    pub uda: Account<'info, SPLUDA>,
+
+    #[account(
+        mut,
+        close = rent_sponsor,
+        seeds = [
+            b"token_vault",
+            uda.mint.as_ref(),
+            uda.key().as_ref(),
+        ],
+        bump,
+        token::mint = uda.mint,
+        token::authority = uda,
+    )]
+    pub token_vault: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        token::mint = uda.mint,
+        token::authority = uda.refund_address,
+    )]
+    pub refund_token_account: Account<'info, TokenAccount>,
+
+    /// CHECK: Validated against stored refund_address - receives excess SOL
+    #[account(
+        mut,
+        address = uda.refund_address
+    )]
+    pub refund_address: AccountInfo<'info>,
+
+    /// CHECK: Validated against stored rent_sponsor - receives rent back (and pays for new accounts)
+    #[account(mut, address = uda.rent_sponsor)]
+    pub rent_sponsor: Signer<'info>,
+
+    /// Identity PDA reused from standard initiate flow (created once, empty seed array)
+    #[account(
+        init_if_needed,
+        payer = rent_sponsor,
+        seeds = [],
+        bump,
+        space = ANCHOR_DISCRIMINATOR,
+    )]
+    pub identity_pda: AccountInfo<'info>,
+
+    /// Swap data account (created here to mirror standard initiate flow) storing absolute timelock
+    #[account(
+        init,
+        payer = rent_sponsor,
+        seeds = [
+            uda.redeemer.as_ref(),
+            uda.refund_address.as_ref(),
+            &uda.secret_hash,
+            &uda.amount.to_le_bytes(),
+            &uda.timelock.to_le_bytes(),
+        ],
+        bump,
+        space = ANCHOR_DISCRIMINATOR + SwapAccount::INIT_SPACE,
+    )]
+    pub swap_data: Account<'info, SwapAccount>,
+
+    /// Per-UDA HTLC vault that actually escrows the swap amount (unique per UDA)
+    #[account(
+        init,
+        payer = rent_sponsor,
+        seeds = [b"htlc_vault", uda.key().as_ref()],
+        bump,
+        token::mint = mint_account,
+        token::authority = identity_pda,
+    )]
+    pub spl_token_vault: Account<'info, TokenAccount>,
+
+    pub mint_account: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
 /// Represents the initiated state of the swap where the funder has deposited funds into the vault
 #[event]
 pub struct Initiated {
@@ -498,6 +850,23 @@ pub struct InstantRefunded {
     pub timelock: u64,
 }
 
+#[event]
+pub struct SPLUDACreated {
+    pub uda_address: Pubkey,
+    pub vault_address: Pubkey,
+    pub refund_address: Pubkey,
+    pub amount: u64,
+    pub timelock: u64,
+}
+
+#[event]
+pub struct HTLCInitiated {
+    pub uda_address: Pubkey,
+    pub htlc_program: Pubkey,
+    pub swap_amount: u64,
+    pub timelock: u64,
+}
+
 #[error_code]
 pub enum SwapError {
     #[msg("The provider redeemer is not the original redeemer of this swap")]
@@ -511,4 +880,52 @@ pub enum SwapError {
 
     #[msg("Attempt to refund before timelock expiry")]
     RefundBeforeExpiry,
+}
+
+#[error_code]
+pub enum UDAError {
+    #[msg("Invalid timelock - must be greater than zero")]
+    InvalidTimelock,
+
+    #[msg("Amount cannot be zero")]
+    ZeroAmount,
+
+    #[msg("Invalid address - cannot be zero address")]
+    InvalidAddress,
+
+    #[msg("Refund address and redeemer cannot be the same")]
+    SameAddress,
+
+    #[msg("Invalid UDA state for this operation")]
+    InvalidState,
+
+    #[msg("UDA has expired")]
+    Expired,
+
+    #[msg("Insufficient funds in UDA")]
+    InsufficientFunds,
+
+    #[msg("Invalid refund address")]
+    InvalidRefundAddress,
+
+    #[msg("Invalid HTLC program address")]
+    InvalidHTLCProgram,
+
+    #[msg("Invalid secret hash - cannot be zero")]
+    InvalidSecretHash,
+
+    #[msg("Invalid mint address")]
+    InvalidMint,
+
+    #[msg("Unauthorized operation")]
+    Unauthorized,
+    
+    #[msg("Token already registered")]
+    TokenAlreadyRegistered,
+
+    #[msg("Invalid destination data provided")]
+    InvalidDestinationData,
+
+    #[msg("Destination hash does not match destination data")]
+    DestinationHashMismatchComputedHash,
 }

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -12,9 +12,6 @@ pub mod solana_spl_swaps {
     use super::*;
 
     /// Initiates the atomic swap. Funds are transferred from the initiator to the token vault.
-    /// As such, the initiator's signature is required for this instruction.
-    /// A sponsor may be involved, who pays PDA rent and transaction fees in SOL, allowing for the
-    /// initiator to participate without holding SOL. As such, the sponsor must also sign this transaction.
     /// `swap_amount` represents the quantity of tokens to be transferred through this atomic swap
     /// in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals
@@ -34,7 +31,7 @@ pub mod solana_spl_swaps {
             initiator,
             initiator_token_account,
             mint,
-            sponsor,
+            rent_sponsor,
             token_program,
             token_vault,
             ..
@@ -57,7 +54,7 @@ pub mod solana_spl_swaps {
             secret_hash,
             swap_amount,
             identity_pda_bump: ctx.bumps.identity_pda,
-            sponsor: sponsor.key(),
+            rent_sponsor: rent_sponsor.key(),
         };
 
         emit!(Initiated {
@@ -223,7 +220,7 @@ pub struct SwapAccount {
     pub identity_pda_bump: u8,
     /// The entity that paid the rent fees for the creation of this PDA.
     /// This will be referenced during the refund of the same upon closing this PDA.
-    pub sponsor: Pubkey,
+    pub rent_sponsor: Pubkey,
 }
 
 #[derive(Accounts)]
@@ -238,7 +235,7 @@ pub struct Initiate<'info> {
     /// using the `init_if_needed` attribute, and be reused for all succeeding instructions.
     #[account(
         init_if_needed,
-        payer = sponsor,
+        payer = rent_sponsor,
         seeds = [],
         bump,
         space = ANCHOR_DISCRIMINATOR,
@@ -251,7 +248,7 @@ pub struct Initiate<'info> {
     /// This PDA will be deleted upon completion of the swap.
     #[account(
         init,
-        payer = sponsor,
+        payer = rent_sponsor,
         seeds = [initiator.key().as_ref(), &secret_hash],
         bump,
         space = ANCHOR_DISCRIMINATOR + SwapAccount::INIT_SPACE,
@@ -266,7 +263,7 @@ pub struct Initiate<'info> {
     /// of every distinct mint using the `init_if_needed` attribute.
     #[account(
         init_if_needed,
-        payer = sponsor,
+        payer = rent_sponsor,
         seeds = [mint.key().as_ref()],
         bump,
         token::mint = mint,
@@ -293,7 +290,7 @@ pub struct Initiate<'info> {
     /// Upon completion of the swap, the PDA rent refund resulting from the
     /// deletion of `swap_data` will be refunded to this address.
     #[account(mut)]
-    pub sponsor: Signer<'info>,
+    pub rent_sponsor: Signer<'info>,
 
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,
@@ -306,12 +303,12 @@ pub struct Redeem<'info> {
     pub identity_pda: AccountInfo<'info>,
 
     /// The PDA holding the state information of the atomic swap. Will be closed upon successful execution
-    /// and the resulting rent refund will be sent to the sponsor.
+    /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
         seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
         bump,
-        close = sponsor,
+        close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
 
@@ -323,9 +320,9 @@ pub struct Redeem<'info> {
     #[account(mut, token::authority = swap_data.redeemer)]
     pub redeemer_token_account: Account<'info, TokenAccount>,
 
-    /// CHECK: Sponsor's address for refunding PDA rent
-    #[account(mut, address = swap_data.sponsor @ SwapError::InvalidSponsor)]
-    pub sponsor: AccountInfo<'info>,
+    /// CHECK: Rent sponsor's address for refunding PDA rent
+    #[account(mut, address = swap_data.rent_sponsor @ SwapError::InvalidRentSponsor)]
+    pub rent_sponsor: AccountInfo<'info>,
 
     pub token_program: Program<'info, Token>,
 }
@@ -337,12 +334,12 @@ pub struct Refund<'info> {
     pub identity_pda: AccountInfo<'info>,
 
     /// The PDA holding the state information of the atomic swap. Will be closed upon successful execution
-    /// and the resulting rent refund will be sent to the sponsor.
+    /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
         seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
         bump,
-        close = sponsor,
+        close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
 
@@ -354,9 +351,9 @@ pub struct Refund<'info> {
     #[account(mut, token::authority = swap_data.initiator)]
     pub initiator_token_account: Account<'info, TokenAccount>,
 
-    /// CHECK: Sponsor's address for refunding PDA rent
-    #[account(mut, address = swap_data.sponsor @ SwapError::InvalidSponsor)]
-    pub sponsor: AccountInfo<'info>,
+    /// CHECK: Rent sponsor's address for refunding PDA rent
+    #[account(mut, address = swap_data.rent_sponsor @ SwapError::InvalidRentSponsor)]
+    pub rent_sponsor: AccountInfo<'info>,
 
     pub token_program: Program<'info, Token>,
 }
@@ -368,12 +365,12 @@ pub struct InstantRefund<'info> {
     pub identity_pda: AccountInfo<'info>,
 
     /// The PDA holding the state information of the atomic swap. Will be closed upon successful execution
-    /// and the resulting rent refund will be sent to the sponsor.
+    /// and the resulting rent refund will be sent to the rent_sponsor.
     #[account(
         mut,
         seeds = [swap_data.initiator.as_ref(), &swap_data.secret_hash],
         bump,
-        close = sponsor,
+        close = rent_sponsor,
     )]
     pub swap_data: Account<'info, SwapAccount>,
 
@@ -389,9 +386,9 @@ pub struct InstantRefund<'info> {
     #[account(mut, address = swap_data.redeemer @ SwapError::InvalidRedeemer)]
     pub redeemer: Signer<'info>,
 
-    /// CHECK: Sponsor's address for PDA rent refund
-    #[account(mut, address = swap_data.sponsor @ SwapError::InvalidSponsor)]
-    pub sponsor: AccountInfo<'info>,
+    /// CHECK: Rent sponsor's address for PDA rent refund
+    #[account(mut, address = swap_data.rent_sponsor @ SwapError::InvalidRentSponsor)]
+    pub rent_sponsor: AccountInfo<'info>,
 
     pub token_program: Program<'info, Token>,
 }
@@ -439,8 +436,8 @@ pub enum SwapError {
     #[msg("The provided secret does not correspond to the secret hash of this swap")]
     InvalidSecret,
 
-    #[msg("The provided sponsor is not the original sponsor of this swap")]
-    InvalidSponsor,
+    #[msg("The provided rent_sponsor is not the original rent_sponsor of this swap")]
+    InvalidRentSponsor,
 
     #[msg("Attempt to perform a refund before expiry time")]
     RefundBeforeExpiry,

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -265,6 +265,7 @@ pub mod solana_spl_swaps {
         destination_data: Vec<u8>,
         destination_hash: [u8; 32]
     ) -> Result<Pubkey> {
+        require!(timelock > 0, UDAError::InvalidTimelock);
         require!(amount > 0, UDAError::ZeroAmount);
         require!(refund_address != redeemer, UDAError::SameAddress);
         require!(refund_address != Pubkey::default(), UDAError::InvalidAddress);
@@ -277,6 +278,7 @@ pub mod solana_spl_swaps {
 
         let uda = &mut ctx.accounts.uda;
         require!(uda.key() != redeemer, UDAError::SameAddress);
+        require!(ctx.accounts.mint_account.key() == mint, UDAError::InvalidMint);
 
         uda.mint = mint;
         uda.refund_address = refund_address;
@@ -320,13 +322,11 @@ pub mod solana_spl_swaps {
     /// * `InvalidHTLCProgram` - If HTLC program doesn't match UDA registration
     /// * `InvalidMint` - If token mint doesn't match UDA mint
     /// * `InsufficientFunds` - If token vault doesn't have enough tokens
-    pub fn initiate_htlc_spl(ctx: Context<InitiateHtlcSpl>) -> Result<()> {
+    pub fn initiate_uda(ctx: Context<InitiateUDA>) -> Result<()> {
         let uda = &mut ctx.accounts.uda;
 
-        require!(uda.timelock > 0, UDAError::InvalidTimelock);
-
         require!(
-            ctx.accounts.mint_account.key() == uda.mint,
+            ctx.accounts.mint_account.key() == uda.mint || ctx.accounts.token_vault.mint == uda.mint,
             UDAError::InvalidMint
         );
 
@@ -334,10 +334,6 @@ pub mod solana_spl_swaps {
             ctx.accounts.token_vault.amount >= uda.amount,
             UDAError::InsufficientFunds
         );
-
-        let current_slot = Clock::get()?.slot;
-    // For UDA path we expect uda.timelock to already be an absolute slot (expiry)
-    if current_slot > uda.timelock { return err!(UDAError::Expired); }
 
         // Store values we need before creating signer seeds
         let mint = uda.mint;
@@ -360,22 +356,27 @@ pub mod solana_spl_swaps {
             &destination_hash,
         ]];
 
-        // Transfer the exact swap amount from the UDA's staging vault into the uniquely derived HTLC vault
+        // Transfer the exact swap amount from the UDA's staging vault into the HTLC vault
         let transfer_ctx = CpiContext::new_with_signer(
             ctx.accounts.token_program.to_account_info(),
             token::Transfer {
                 from: ctx.accounts.token_vault.to_account_info(),      // UDA staging vault
-                to: ctx.accounts.spl_token_vault.to_account_info(),    // Per-UDA HTLC vault
+                to: ctx.accounts.spl_token_vault.to_account_info(),    // HTLC vault
                 authority: uda.to_account_info(),                      // UDA PDA authority
             },
             uda_signer_seeds,
         );
-    token::transfer(transfer_ctx, amount)?;
+        token::transfer(transfer_ctx, amount)?;
+
+        let expiry_slot = Clock::get()?
+            .slot
+            .checked_add(timelock)
+            .expect("timelock should not cause an overflow");
 
         // Initialize the swap data account (created in this instruction via Init constraint)
         // For UDA path we store absolute timelock (same as expiry_slot) to keep seeds deterministic.
         *ctx.accounts.swap_data = SwapAccount {
-            expiry_slot: timelock, // absolute expiry slot
+            expiry_slot,
             bump: ctx.bumps.swap_data,
             identity_pda_bump: ctx.bumps.identity_pda,
             rent_sponsor: ctx.accounts.rent_sponsor.key(),
@@ -403,11 +404,8 @@ pub mod solana_spl_swaps {
             token::transfer(residual_ctx, residual)?;
         }
 
-        uda.initiated_at = Some(Clock::get()?.slot);
-
         emit!(HTLCInitiated {
             uda_address: uda.key(),
-            htlc_program: uda.htlc_program,
             swap_amount: uda.amount,
             timelock: uda.timelock,
         });
@@ -425,11 +423,10 @@ pub struct SPLUDA {
     pub timelock: u64,
     pub secret_hash: [u8; 32],
     pub amount: u64,
-    pub htlc_program: Pubkey,
     pub vault_address: Pubkey,
     pub created_at: u64,        // Slot when UDA was created (0 = not created, >0 = created)
     pub rent_sponsor: Pubkey, // Who paid for UDA creation (gets rent back)
-    #[max_len(10240)]  // Large limit - user pays for storage
+    #[max_len(1024)]  // Large limit - user pays for storage
     pub destination_data: Vec<u8>, // Destination data for cross-chain/routing purposes
     pub destination_hash: [u8; 32],  // SHA256 hash of destination_data for PDA seeds
 }
@@ -709,7 +706,7 @@ pub struct CreateSPLUDA<'info> {
 }
 
 #[derive(Accounts)]
-pub struct InitiateHtlcSpl<'info> {
+pub struct InitiateUDA<'info> {
     #[account(
         mut,
         close = rent_sponsor,
@@ -721,7 +718,6 @@ pub struct InitiateHtlcSpl<'info> {
             &uda.secret_hash,
             &uda.amount.to_le_bytes(),
             &uda.timelock.to_le_bytes(),
-            uda.htlc_program.as_ref(),
             &uda.destination_hash,
         ],
         bump,
@@ -786,11 +782,11 @@ pub struct InitiateHtlcSpl<'info> {
     )]
     pub swap_data: Account<'info, SwapAccount>,
 
-    /// Per-UDA HTLC vault that actually escrows the swap amount (unique per UDA)
+    /// Standard HTLC token vault (shared across swaps for same mint, matches Initiate struct)
     #[account(
-        init,
+        init_if_needed,
         payer = rent_sponsor,
-        seeds = [b"htlc_vault", uda.key().as_ref()],
+        seeds = [mint_account.key().as_ref()],
         bump,
         token::mint = mint_account,
         token::authority = identity_pda,
@@ -862,7 +858,6 @@ pub struct SPLUDACreated {
 #[event]
 pub struct HTLCInitiated {
     pub uda_address: Pubkey,
-    pub htlc_program: Pubkey,
     pub swap_amount: u64,
     pub timelock: u64,
 }

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -16,15 +16,15 @@ pub mod solana_spl_swaps {
     /// in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals
     /// must be provided as 1,000,000.  
-    /// `expires_in_slots` represents the number of slots after which (non-instant) refunds are allowed.  
+    /// `timelock` represents the number of slots after which (non-instant) refunds are allowed.  
     /// `destination_data` can hold optional information regarding the destination chain
     /// in the atomic swap, to be emitted in the logs as-is.
     pub fn initiate(
         ctx: Context<Initiate>,
-        expires_in_slots: u64,
         redeemer: Pubkey,
         secret_hash: [u8; 32],
         swap_amount: u64, // In base units of the token
+        timelock: u64,
         destination_data: Option<Vec<u8>>,
     ) -> Result<()> {
         let Initiate {
@@ -48,17 +48,18 @@ pub mod solana_spl_swaps {
         token::transfer(token_transfer_context, swap_amount)?;
 
         *ctx.accounts.swap_data = SwapAccount {
+            expiry_slot: Clock::get()?.slot + timelock,
+            identity_pda_bump: ctx.bumps.identity_pda,
+            rent_sponsor: rent_sponsor.key(),
             initiator: initiator.key(),
-            expiry_slot: Clock::get()?.slot + expires_in_slots,
             redeemer,
             secret_hash,
             swap_amount,
-            identity_pda_bump: ctx.bumps.identity_pda,
-            rent_sponsor: rent_sponsor.key(),
+            timelock,
         };
 
         emit!(Initiated {
-            expires_in_slots,
+            timelock,
             initiator: initiator.key(),
             mint: mint.key(),
             redeemer,
@@ -203,6 +204,13 @@ pub mod solana_spl_swaps {
 pub struct SwapAccount {
     /// The exact slot after which (non-instant) refunds are allowed
     pub expiry_slot: u64,
+    /// The bump associated with the identity pda.
+    /// This is needed by the program to authorize token transfers via the token vault.
+    pub identity_pda_bump: u8,
+    /// The entity that paid the rent fees for the creation of this PDA.
+    /// This will be referenced during the refund of the same upon closing this PDA.
+    pub rent_sponsor: Pubkey,
+
     /// The initiator of the atomic swap
     pub initiator: Pubkey,
     /// The redeemer of the atomic swap
@@ -215,19 +223,15 @@ pub struct SwapAccount {
     /// must be provided as 1,000,000.
     pub swap_amount: u64,
 
-    /// The bump associated with the identity pda.
-    /// This is needed by the program to authorize token transfers via the token vault.
-    pub identity_pda_bump: u8,
-    /// The entity that paid the rent fees for the creation of this PDA.
-    /// This will be referenced during the refund of the same upon closing this PDA.
-    pub rent_sponsor: Pubkey,
+    /// Represents the number of slots after which (non-instant) refunds are allowed
+    pub timelock: u64,
 }
 
 #[derive(Accounts)]
 // The parameters must have the exact name and order as specified in the underlying function
 // to avoid "seed constraint violation" errors.
 // Refer: https://www.anchor-lang.com/docs/references/account-constraints#instruction-attribute
-#[instruction(expires_in_slots: u64, redeemer_token_account: Pubkey, secret_hash: [u8; 32])]
+#[instruction(redeemer: Pubkey, secret_hash: [u8; 32], swap_amount: u64, timelock: u64)]
 pub struct Initiate<'info> {
     /// CHECK: A permanent PDA that represents this swap program for authorizing
     /// the token transfers of the `token_vault` PDA.  
@@ -399,8 +403,8 @@ pub struct Initiated {
     /// The quantity of tokens transferred through this atomic swap in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals will be represented as 1,000,000.
     pub swap_amount: u64,
-    /// `expires_in_slots` represents the number of slots after which (non-instant) refunds are allowed
-    pub expires_in_slots: u64,
+    /// `timelock` represents the number of slots after which (non-instant) refunds are allowed
+    pub timelock: u64,
     pub initiator: Pubkey,
     pub mint: Pubkey,
     pub redeemer: Pubkey,
@@ -439,6 +443,6 @@ pub enum SwapError {
     #[msg("The provided rent_sponsor is not the original rent_sponsor of this swap")]
     InvalidRentSponsor,
 
-    #[msg("Attempt to perform a refund before expiry time")]
+    #[msg("Attempt to refund before timelock expiry")]
     RefundBeforeExpiry,
 }

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -288,10 +288,8 @@ pub mod solana_spl_swaps {
 
         emit!(SPLUDACreated {
             uda_address: uda.key(),
-            vault_address: ctx.accounts.uda_token_vault.key(),
-            refund_address: uda.refund_address,
-            amount: uda.amount,
-            timelock: uda.timelock,
+            uda: uda.clone().into_inner(),
+            
         });
 
         Ok(ctx.accounts.uda_token_vault.key())
@@ -839,10 +837,7 @@ pub struct InstantRefunded {
 #[event]
 pub struct SPLUDACreated {
     pub uda_address: Pubkey,
-    pub vault_address: Pubkey,
-    pub refund_address: Pubkey,
-    pub amount: u64,
-    pub timelock: u64,
+    pub uda: SPLUDA
 }
 
 #[event]

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -265,8 +265,6 @@ pub mod solana_spl_swaps {
         destination_data: Vec<u8>,
         destination_hash: [u8; 32]
     ) -> Result<Pubkey> {
-        require!(timelock > 0, UDAError::InvalidTimelock);
-        require!(amount > 0, UDAError::ZeroAmount);
         require!(refund_address != redeemer, UDAError::SameAddress);
         require!(refund_address != Pubkey::default(), UDAError::InvalidAddress);
         require!(redeemer != Pubkey::default(), UDAError::InvalidAddress);
@@ -286,21 +284,22 @@ pub mod solana_spl_swaps {
         uda.timelock = timelock;
         uda.secret_hash = secret_hash;
         uda.amount = amount;
-        uda.vault_address = ctx.accounts.token_vault.key();
+        uda.vault_address = ctx.accounts.uda_token_vault.key();
         uda.created_at = Clock::get()?.slot;
         uda.rent_sponsor = ctx.accounts.payer.key();
         uda.destination_data = destination_data.clone();
         uda.destination_hash = destination_hash;
+        uda.identity_pda_bump = ctx.bumps.identity_pda;
 
         emit!(SPLUDACreated {
             uda_address: uda.key(),
-            vault_address: ctx.accounts.token_vault.key(),
+            vault_address: ctx.accounts.uda_token_vault.key(),
             refund_address: uda.refund_address,
             amount: uda.amount,
             timelock: uda.timelock,
         });
 
-        Ok(ctx.accounts.token_vault.key())
+        Ok(ctx.accounts.uda_token_vault.key())
     }
 
     /// Initiate Hash Time Lock Contract for an SPL token UDA
@@ -327,13 +326,13 @@ pub mod solana_spl_swaps {
 
         require!(
             ctx.accounts.mint_account.key() == uda.mint && 
-            ctx.accounts.token_vault.mint == uda.mint && 
+            ctx.accounts.uda_token_vault.mint == uda.mint && 
             ctx.accounts.refund_token_account.key() == uda.mint,
             UDAError::InvalidMint
         );
 
         require!(
-            ctx.accounts.token_vault.amount >= uda.amount,
+            ctx.accounts.uda_token_vault.amount >= uda.amount,
             UDAError::InsufficientFunds
         );
 
@@ -344,29 +343,16 @@ pub mod solana_spl_swaps {
         let secret_hash = uda.secret_hash;
         let amount = uda.amount;
         let timelock = uda.timelock;
-        let destination_hash = uda.destination_hash;
-
-        // UDA signer seeds (authority over the pre-init vault holding initial funds)
-        let uda_signer_seeds: &[&[&[u8]]] = &[&[
-            b"spl_uda",
-            mint.as_ref(),
-            refund_address.as_ref(),
-            redeemer.as_ref(),
-            &secret_hash,
-            &amount.to_le_bytes(),
-            &timelock.to_le_bytes(),
-            &destination_hash,
-        ]];
 
         // Transfer the exact swap amount from the UDA's staging vault into the HTLC vault
         let transfer_ctx = CpiContext::new(
             ctx.accounts.token_program.to_account_info(),
             token::Transfer {
-                from: ctx.accounts.token_vault.to_account_info(),      // UDA staging vault
-                to: ctx.accounts.spl_token_vault.to_account_info(),    // HTLC vault
-                authority: uda.to_account_info(),                      // UDA PDA authority
+                from: ctx.accounts.uda_token_vault.to_account_info(),      // UDA staging vault
+                to: ctx.accounts.token_vault.to_account_info(),            // HTLC vault
+                authority: uda.to_account_info(),                          // UDA PDA authority
             },
-        ); // @audit-ok
+        );
         token::transfer(transfer_ctx, amount)?;
 
         let expiry_slot = Clock::get()?
@@ -379,7 +365,7 @@ pub mod solana_spl_swaps {
         *ctx.accounts.swap_data = SwapAccount {
             expiry_slot,
             bump: ctx.bumps.swap_data,
-            identity_pda_bump: ctx.bumps.identity_pda,
+            identity_pda_bump: uda.identity_pda_bump,
             rent_sponsor: ctx.accounts.rent_sponsor.key(),
             mint,
             redeemer,
@@ -390,13 +376,13 @@ pub mod solana_spl_swaps {
         };
 
         // After moving the required amount, send any residual balance in the staging vault back to the refund address
-        ctx.accounts.token_vault.reload()?;
-        let residual = ctx.accounts.token_vault.amount;
+        ctx.accounts.uda_token_vault.reload()?;
+        let residual = ctx.accounts.uda_token_vault.amount;
         if residual > 0 {
             let residual_ctx = CpiContext::new(
                 ctx.accounts.token_program.to_account_info(),
                 token::Transfer {
-                    from: ctx.accounts.token_vault.to_account_info(),
+                    from: ctx.accounts.uda_token_vault.to_account_info(),
                     to: ctx.accounts.refund_token_account.to_account_info(),
                     authority: uda.to_account_info(),
                 },
@@ -439,6 +425,7 @@ pub struct SPLUDA {
     #[max_len(1024)]  // Large limit - user pays for storage
     pub destination_data: Vec<u8>, // Destination data for cross-chain/routing purposes
     pub destination_hash: [u8; 32],  // SHA256 hash of destination_data for PDA seeds
+    pub identity_pda_bump: u8
 }
 
 /// Stores the state information of the atomic swap on-chain
@@ -692,8 +679,11 @@ pub struct CreateSPLUDA<'info> {
     )]
     pub uda: Account<'info, SPLUDA>,
 
+    #[account(seeds = [], bump)]
+    pub identity_pda: AccountInfo<'info>,
+
     #[account(
-        init_if_needed,
+        init,
         payer = payer,
         seeds = [
             b"token_vault",
@@ -704,7 +694,7 @@ pub struct CreateSPLUDA<'info> {
         token::mint = mint_account,
         token::authority = uda,
     )]
-    pub token_vault: Account<'info, TokenAccount>,
+    pub uda_token_vault: Account<'info, TokenAccount>,
 
     pub mint_account: Account<'info, Mint>,
 
@@ -746,7 +736,7 @@ pub struct InitiateUDA<'info> {
         token::mint = uda.mint,
         token::authority = uda,
     )]
-    pub token_vault: Account<'info, TokenAccount>,
+    pub uda_token_vault: Account<'info, TokenAccount>,
 
     #[account(
         mut,
@@ -767,7 +757,7 @@ pub struct InitiateUDA<'info> {
     pub rent_sponsor: Signer<'info>,
 
     /// Identity PDA reused from standard initiate flow (created once, empty seed array)
-    #[account(seeds = [], bump = swap_data.identity_pda_bump)]
+    #[account(seeds = [], bump = uda.identity_pda_bump)]
     pub identity_pda: AccountInfo<'info>,
 
     /// Swap data account (created here to mirror standard initiate flow) storing absolute timelock
@@ -796,7 +786,7 @@ pub struct InitiateUDA<'info> {
         token::mint = mint_account,
         token::authority = identity_pda,
     )]
-    pub spl_token_vault: Account<'info, TokenAccount>,
+    pub token_vault: Account<'info, TokenAccount>,
 
     pub mint_account: Account<'info, Mint>,
 

--- a/programs/solana-spl-swaps/src/lib.rs
+++ b/programs/solana-spl-swaps/src/lib.rs
@@ -11,7 +11,7 @@ const ANCHOR_DISCRIMINATOR: usize = 8;
 pub mod solana_spl_swaps {
     use super::*;
 
-    /// Initiates the atomic swap. Funds are transferred from the initiator to the token vault.
+    /// Initiates the atomic swap. Funds are transferred from the funder to the token vault.
     /// `swap_amount` represents the quantity of tokens to be transferred through this atomic swap
     /// in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals
@@ -22,14 +22,15 @@ pub mod solana_spl_swaps {
     pub fn initiate(
         ctx: Context<Initiate>,
         redeemer: Pubkey,
+        refundee: Pubkey,
         secret_hash: [u8; 32],
         swap_amount: u64, // In base units of the token
         timelock: u64,
         destination_data: Option<Vec<u8>>,
     ) -> Result<()> {
         let Initiate {
-            initiator,
-            initiator_token_account,
+            funder,
+            funder_token_account,
             mint,
             rent_sponsor,
             token_program,
@@ -40,9 +41,9 @@ pub mod solana_spl_swaps {
         let token_transfer_context = CpiContext::new(
             token_program.to_account_info(),
             token::Transfer {
-                from: initiator_token_account.to_account_info(),
+                from: funder_token_account.to_account_info(),
                 to: token_vault.to_account_info(),
-                authority: initiator.to_account_info(),
+                authority: funder.to_account_info(),
             },
         );
         token::transfer(token_transfer_context, swap_amount)?;
@@ -52,9 +53,9 @@ pub mod solana_spl_swaps {
             bump: ctx.bumps.swap_data,
             identity_pda_bump: ctx.bumps.identity_pda,
             rent_sponsor: rent_sponsor.key(),
-            initiator: initiator.key(),
             mint: mint.key(),
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             timelock,
@@ -62,9 +63,9 @@ pub mod solana_spl_swaps {
 
         emit!(Initiated {
             timelock,
-            initiator: initiator.key(),
             mint: mint.key(),
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             destination_data,
@@ -85,9 +86,9 @@ pub mod solana_spl_swaps {
         } = ctx.accounts;
         let SwapAccount {
             identity_pda_bump,
-            initiator,
             mint,
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             timelock,
@@ -112,9 +113,9 @@ pub mod solana_spl_swaps {
         token::transfer(token_transfer_context, swap_amount)?;
 
         emit!(Redeemed {
-            initiator,
             mint,
             redeemer,
+            refundee,
             secret,
             swap_amount,
             timelock,
@@ -123,13 +124,13 @@ pub mod solana_spl_swaps {
         Ok(())
     }
 
-    /// Funds are returned to the initiator, given that no redeems have occured
+    /// Funds are returned to the refundee, given that no redeems have occured
     /// and the expiry slot has been reached.
     /// This instruction does not require any signatures.
     pub fn refund(ctx: Context<Refund>) -> Result<()> {
         let Refund {
             identity_pda,
-            initiator_token_account,
+            refundee_token_account,
             swap_data,
             token_vault,
             token_program,
@@ -137,9 +138,9 @@ pub mod solana_spl_swaps {
         } = ctx.accounts;
         let SwapAccount {
             identity_pda_bump,
-            initiator,
             mint,
             redeemer,
+            refundee,
             expiry_slot,
             secret_hash,
             swap_amount,
@@ -157,7 +158,7 @@ pub mod solana_spl_swaps {
             token_program.to_account_info(),
             token::Transfer {
                 from: token_vault.to_account_info(),
-                to: initiator_token_account.to_account_info(),
+                to: refundee_token_account.to_account_info(),
                 authority: identity_pda.to_account_info(),
             },
         )
@@ -165,9 +166,9 @@ pub mod solana_spl_swaps {
         token::transfer(token_transfer_context, swap_amount)?;
 
         emit!(Refunded {
-            initiator,
             mint,
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             timelock,
@@ -176,13 +177,13 @@ pub mod solana_spl_swaps {
         Ok(())
     }
 
-    /// Funds are returned to the initiator, with the redeemer's consent.
+    /// Funds are returned to the refundee, with the redeemer's consent.
     /// As such, the redeemer's signature is required for this instruction.
     /// This allows for refunds before the expiry slot.
     pub fn instant_refund(ctx: Context<InstantRefund>) -> Result<()> {
         let InstantRefund {
             identity_pda,
-            initiator_token_account,
+            refundee_token_account,
             swap_data,
             token_program,
             token_vault,
@@ -190,9 +191,9 @@ pub mod solana_spl_swaps {
         } = ctx.accounts;
         let SwapAccount {
             identity_pda_bump,
-            initiator,
             mint,
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             timelock,
@@ -204,7 +205,7 @@ pub mod solana_spl_swaps {
             token_program.to_account_info(),
             token::Transfer {
                 from: token_vault.to_account_info(),
-                to: initiator_token_account.to_account_info(),
+                to: refundee_token_account.to_account_info(),
                 authority: identity_pda.to_account_info(),
             },
         )
@@ -212,9 +213,9 @@ pub mod solana_spl_swaps {
         token::transfer(token_transfer_context, swap_amount)?;
 
         emit!(InstantRefunded {
-            initiator,
             mint,
             redeemer,
+            refundee,
             secret_hash,
             swap_amount,
             timelock,
@@ -240,12 +241,12 @@ pub struct SwapAccount {
     /// This will be referenced during the refund of the same upon closing this PDA.
     pub rent_sponsor: Pubkey,
 
-    /// The initiator of the atomic swap
-    pub initiator: Pubkey,
     /// The mint for this atomic swap
     pub mint: Pubkey,
     /// The redeemer of the atomic swap
     pub redeemer: Pubkey,
+    /// The refundee of the atomic swap
+    pub refundee: Pubkey,
     /// The secret hash associated with the atomic swap
     pub secret_hash: [u8; 32],
     /// The quantity tokens to be transferred through this atomic swap
@@ -253,7 +254,6 @@ pub struct SwapAccount {
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals
     /// must be provided as 1,000,000.
     pub swap_amount: u64,
-
     /// Represents the number of slots after which (non-instant) refunds are allowed
     pub timelock: u64,
 }
@@ -262,7 +262,7 @@ pub struct SwapAccount {
 // The parameters must have the exact name and order as specified in the underlying function
 // to avoid "seed constraint violation" errors.
 // Refer: https://www.anchor-lang.com/docs/references/account-constraints#instruction-attribute
-#[instruction(redeemer: Pubkey, secret_hash: [u8; 32], swap_amount: u64, timelock: u64)]
+#[instruction(redeemer: Pubkey, refundee: Pubkey, secret_hash: [u8; 32], swap_amount: u64, timelock: u64)]
 pub struct Initiate<'info> {
     /// CHECK: A permanent PDA that represents this swap program for authorizing
     /// the token transfers of the `token_vault` PDA.  
@@ -284,8 +284,8 @@ pub struct Initiate<'info> {
         init,
         payer = rent_sponsor,
         seeds = [
-            initiator.key().as_ref(),
             redeemer.as_ref(),
+            refundee.as_ref(),
             &secret_hash,
             &swap_amount.to_le_bytes(),
             &timelock.to_le_bytes(),
@@ -311,16 +311,17 @@ pub struct Initiate<'info> {
     )]
     pub token_vault: Account<'info, TokenAccount>,
 
-    /// The initiator of the atomic swap. They must sign this transaction.
-    pub initiator: Signer<'info>,
+    /// The party that deposits the funds to be involved in the atomic swap.
+    /// They must sign this transaction.
+    pub funder: Signer<'info>,
 
-    /// The token account of the initiator
+    /// The token account of the funder
     #[account(
         mut,
         token::mint = mint,
-        token::authority = initiator,
+        token::authority = funder,
     )]
-    pub initiator_token_account: Account<'info, TokenAccount>,
+    pub funder_token_account: Account<'info, TokenAccount>,
 
     /// The mint of the tokens involved in this swap. As this is a parameter, this program can thus be reused
     /// for atomic swaps with different mints.
@@ -347,8 +348,8 @@ pub struct Redeem<'info> {
     #[account(
         mut,
         seeds = [
-            swap_data.initiator.key().as_ref(),
             swap_data.redeemer.as_ref(),
+            swap_data.refundee.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -384,8 +385,8 @@ pub struct Refund<'info> {
     #[account(
         mut,
         seeds = [
-            swap_data.initiator.key().as_ref(),
             swap_data.redeemer.as_ref(),
+            swap_data.refundee.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -399,9 +400,9 @@ pub struct Refund<'info> {
     #[account(mut, token::authority = identity_pda)]
     pub token_vault: Account<'info, TokenAccount>,
 
-    /// CHECK: The token account of the initiator
-    #[account(mut, token::authority = swap_data.initiator)]
-    pub initiator_token_account: Account<'info, TokenAccount>,
+    /// CHECK: The token account of the refundee
+    #[account(mut, token::authority = swap_data.refundee)]
+    pub refundee_token_account: Account<'info, TokenAccount>,
 
     /// CHECK: Rent sponsor's address for refunding PDA rent
     #[account(mut, address = swap_data.rent_sponsor @ SwapError::InvalidRentSponsor)]
@@ -421,8 +422,8 @@ pub struct InstantRefund<'info> {
     #[account(
         mut,
         seeds = [
-            swap_data.initiator.key().as_ref(),
             swap_data.redeemer.as_ref(),
+            swap_data.refundee.as_ref(),
             &swap_data.secret_hash,
             &swap_data.swap_amount.to_le_bytes(),
             &swap_data.timelock.to_le_bytes(),
@@ -436,9 +437,9 @@ pub struct InstantRefund<'info> {
     #[account(mut, token::authority = identity_pda)]
     pub token_vault: Account<'info, TokenAccount>,
 
-    /// CHECK: The token account of the initiator
-    #[account(mut, token::authority = swap_data.initiator)]
-    pub initiator_token_account: Account<'info, TokenAccount>,
+    /// CHECK: The token account of the refundee
+    #[account(mut, token::authority = swap_data.refundee)]
+    pub refundee_token_account: Account<'info, TokenAccount>,
 
     /// The redeemer of the atomic swap. They must sign this transaction.
     #[account(mut, address = swap_data.redeemer @ SwapError::InvalidRedeemer)]
@@ -451,12 +452,12 @@ pub struct InstantRefund<'info> {
     pub token_program: Program<'info, Token>,
 }
 
-/// Represents the initiated state of the swap where the initiator has deposited funds into the vault
+/// Represents the initiated state of the swap where the funder has deposited funds into the vault
 #[event]
 pub struct Initiated {
-    pub initiator: Pubkey,
     pub mint: Pubkey,
     pub redeemer: Pubkey,
+    pub refundee: Pubkey,
     pub secret_hash: [u8; 32],
     /// The quantity of tokens transferred through this atomic swap in base units of the token mint.  
     /// E.g: A quantity of $1 represented by the token "USDC" with "6" decimals will be represented as 1,000,000.
@@ -469,9 +470,9 @@ pub struct Initiated {
 /// Represents the redeemed state of the swap, where the redeemer has withdrawn funds from the vault
 #[event]
 pub struct Redeemed {
-    pub initiator: Pubkey,
     pub mint: Pubkey,
     pub redeemer: Pubkey,
+    pub refundee: Pubkey,
     pub secret: [u8; 32],
     pub swap_amount: u64,
     pub timelock: u64,
@@ -479,20 +480,20 @@ pub struct Redeemed {
 /// Represents the refund state of the swap, where the initiator has withdrawn funds from the vault past expiry
 #[event]
 pub struct Refunded {
-    pub initiator: Pubkey,
     pub mint: Pubkey,
     pub redeemer: Pubkey,
+    pub refundee: Pubkey,
     pub secret_hash: [u8; 32],
     pub swap_amount: u64,
     pub timelock: u64,
 }
-/// Represents the instant refund state of the swap, where the initiator has withdrawn funds the vault
-/// with the redeemer's consent
+/// Represents the instant refund state of the swap, where the refundee has obtained
+/// a refund of the funds with the redeemer's consent
 #[event]
 pub struct InstantRefunded {
-    pub initiator: Pubkey,
     pub mint: Pubkey,
     pub redeemer: Pubkey,
+    pub refundee: Pubkey,
     pub secret_hash: [u8; 32],
     pub swap_amount: u64,
     pub timelock: u64,

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -46,9 +46,9 @@ describe("Testing one way swap between Alice and Bob", () => {
 
   const [swapData] = web3.PublicKey.findProgramAddressSync(
     [
+      mint.publicKey.toBuffer(),
       bob.publicKey.toBuffer(),
       alice.publicKey.toBuffer(),
-      mint.publicKey.toBuffer(),
       secretHash,
       swapAmount.toArrayLike(Buffer, "le", 8),
       timelock.toArrayLike(Buffer, "le", 8),

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -38,7 +38,7 @@ describe("Testing one way swap between Alice and Bob", () => {
   let bobTokenAccount: web3.PublicKey;
 
   // Sponsors the PDA rent and transaction fees
-  const sponsor = new web3.Keypair();
+  const rentSponsor = new web3.Keypair();
 
   const [swapData] = web3.PublicKey.findProgramAddressSync(
     [alice.publicKey.toBuffer(), secretHash],
@@ -53,9 +53,9 @@ describe("Testing one way swap between Alice and Bob", () => {
 
   before(async () => {
     latestBlockHash = await connection.getLatestBlockhash();
-    // Fund sponsor with 1 SOL
+    // Fund rent sponsor with 1 SOL
     const signature = await connection.requestAirdrop(
-      sponsor.publicKey,
+      rentSponsor.publicKey,
       web3.LAMPORTS_PER_SOL
     );
     await connection.confirmTransaction({ signature, ...latestBlockHash });
@@ -64,7 +64,7 @@ describe("Testing one way swap between Alice and Bob", () => {
     try {
       await spl.createMint(
         connection,
-        sponsor,
+        rentSponsor,
         mintAuthority.publicKey,
         null,
         0,
@@ -75,13 +75,13 @@ describe("Testing one way swap between Alice and Bob", () => {
     }
     aliceTokenAccount = await spl.createAssociatedTokenAccount(
       connection,
-      sponsor,
+      rentSponsor,
       mint.publicKey,
       alice.publicKey
     );
     bobTokenAccount = await spl.createAssociatedTokenAccount(
       connection,
-      sponsor,
+      rentSponsor,
       mint.publicKey,
       bob.publicKey
     );
@@ -89,7 +89,7 @@ describe("Testing one way swap between Alice and Bob", () => {
     // Fund alice's token acc with tokens
     await spl.mintTo(
       connection,
-      sponsor,
+      rentSponsor,
       mint.publicKey,
       aliceTokenAccount,
       mintAuthority,
@@ -103,7 +103,7 @@ Alice     : ${alice.publicKey}\tAlice TokenAcc:\t${aliceTokenAccount}
 Bob       : ${bob.publicKey}\tBob TokenAcc:\t${bobTokenAccount}
 Swap Data : ${swapData}\tToken Vault:\t${tokenVault}
 Mint      : ${mint.publicKey}\tMint Authority:\t${mintAuthority.publicKey}
-Sponsor   : ${sponsor.publicKey}\n`
+Sponsor   : ${rentSponsor.publicKey}\n`
     );
   });
 
@@ -120,9 +120,9 @@ Sponsor   : ${sponsor.publicKey}\n`
         initiator: alice.publicKey,
         initiatorTokenAccount: aliceTokenAccount,
         mint: mint.publicKey,
-        sponsor: sponsor.publicKey,
+        rentSponsor: rentSponsor.publicKey,
       })
-      .signers([alice, sponsor])
+      .signers([alice, rentSponsor])
       .rpc();
     await connection.confirmTransaction({ signature, ...latestBlockHash });
     console.log(`\tInitiate: \t${signature}`);
@@ -148,7 +148,7 @@ Sponsor   : ${sponsor.publicKey}\n`
       .redeem([...secret])
       .accounts({
         redeemerTokenAccount: bobTokenAccount,
-        sponsor: sponsor.publicKey,
+        rentSponsor: rentSponsor.publicKey,
         swapData,
         tokenVault,
       })
@@ -174,7 +174,7 @@ Sponsor   : ${sponsor.publicKey}\n`
       .refund()
       .accounts({
         initiatorTokenAccount: aliceTokenAccount,
-        sponsor: sponsor.publicKey,
+        rentSponsor: rentSponsor.publicKey,
         swapData,
         tokenVault,
       })
@@ -198,7 +198,7 @@ Sponsor   : ${sponsor.publicKey}\n`
       .accounts({
         initiatorTokenAccount: aliceTokenAccount,
         redeemer: bob.publicKey,
-        sponsor: sponsor.publicKey,
+        rentSponsor: rentSponsor.publicKey,
         swapData,
         tokenVault,
       })

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -48,6 +48,7 @@ describe("Testing one way swap between Alice and Bob", () => {
     [
       bob.publicKey.toBuffer(),
       alice.publicKey.toBuffer(),
+      mint.publicKey.toBuffer(),
       secretHash,
       swapAmount.toArrayLike(Buffer, "le", 8),
       timelock.toArrayLike(Buffer, "le", 8),

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -40,10 +40,14 @@ describe("Testing one way swap between Alice and Bob", () => {
   // Sponsors the PDA rent and transaction fees
   const rentSponsor = new web3.Keypair();
 
+  // Facilitates initiate on behalf
+  const funder = new web3.Keypair();
+  let funderTokenAccount: web3.PublicKey;
+
   const [swapData] = web3.PublicKey.findProgramAddressSync(
     [
-      alice.publicKey.toBuffer(),
       bob.publicKey.toBuffer(),
+      alice.publicKey.toBuffer(),
       secretHash,
       swapAmount.toArrayLike(Buffer, "le", 8),
       timelock.toArrayLike(Buffer, "le", 8),
@@ -91,6 +95,12 @@ describe("Testing one way swap between Alice and Bob", () => {
       mint.publicKey,
       bob.publicKey
     );
+    funderTokenAccount = await spl.createAssociatedTokenAccount(
+      connection,
+      rentSponsor,
+      mint.publicKey,
+      funder.publicKey
+    );
 
     // Fund alice's token acc with tokens
     await spl.mintTo(
@@ -98,6 +108,17 @@ describe("Testing one way swap between Alice and Bob", () => {
       rentSponsor,
       mint.publicKey,
       aliceTokenAccount,
+      mintAuthority,
+      swapAmount.toNumber() * 10
+    );
+    await connection.confirmTransaction({ signature, ...latestBlockHash });
+
+    // Fund funder's token acc with tokens
+    await spl.mintTo(
+      connection,
+      rentSponsor,
+      mint.publicKey,
+      funderTokenAccount,
       mintAuthority,
       swapAmount.toNumber() * 10
     );
@@ -117,14 +138,15 @@ Sponsor   : ${rentSponsor.publicKey}\n`
     const signature = await program.methods
       .initiate(
         bob.publicKey,
+        alice.publicKey,
         [...secretHash],
         swapAmount,
         timelock,
         destinationData
       )
       .accounts({
-        initiator: alice.publicKey,
-        initiatorTokenAccount: aliceTokenAccount,
+        funder: alice.publicKey,
+        funderTokenAccount: aliceTokenAccount,
         mint: mint.publicKey,
         rentSponsor: rentSponsor.publicKey,
       })
@@ -134,15 +156,44 @@ Sponsor   : ${rentSponsor.publicKey}\n`
     console.log(`\tInitiate: \t${signature}`);
   }
 
-  it("Test initiation", async () => {
+  it("Test initiate on behalf", async () => {
     const aliceBalanceBefore = (
       await connection.getTokenAccountBalance(aliceTokenAccount)
     ).value.uiAmount;
-    await aliceInitiate();
+    const funderPreBalance = (
+      await connection.getTokenAccountBalance(funderTokenAccount)
+    ).value.uiAmount;
+
+    const signature = await program.methods
+      .initiate(
+        bob.publicKey,
+        alice.publicKey,
+        [...secretHash],
+        swapAmount,
+        timelock,
+        destinationData
+      )
+      .accounts({
+        funder: funder.publicKey,
+        funderTokenAccount,
+        mint: mint.publicKey,
+        rentSponsor: rentSponsor.publicKey,
+      })
+      .signers([funder, rentSponsor])
+      .rpc();
+    console.log(`\tFunder initiated on behalf of alice: \t${signature}`);
+
     const aliceBalance = (
       await connection.getTokenAccountBalance(aliceTokenAccount)
     ).value.uiAmount;
-    expect(aliceBalance - aliceBalanceBefore).to.equal(-swapAmount.toNumber());
+    expect(aliceBalance).to.equal(aliceBalanceBefore);
+
+    const funderPostBalance = (
+      await connection.getTokenAccountBalance(funderTokenAccount)
+    ).value.uiAmount;
+    expect(funderPostBalance).to.equal(
+      funderPreBalance - swapAmount.toNumber()
+    );
   });
 
   it("Test redeem", async () => {
@@ -179,7 +230,7 @@ Sponsor   : ${rentSponsor.publicKey}\n`
     const signature = await program.methods
       .refund()
       .accounts({
-        initiatorTokenAccount: aliceTokenAccount,
+        refundeeTokenAccount: aliceTokenAccount,
         rentSponsor: rentSponsor.publicKey,
         swapData,
         tokenVault,
@@ -202,7 +253,7 @@ Sponsor   : ${rentSponsor.publicKey}\n`
     const signature = await program.methods
       .instantRefund()
       .accounts({
-        initiatorTokenAccount: aliceTokenAccount,
+        refundeeTokenAccount: aliceTokenAccount,
         redeemer: bob.publicKey,
         rentSponsor: rentSponsor.publicKey,
         swapData,

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -41,7 +41,13 @@ describe("Testing one way swap between Alice and Bob", () => {
   const rentSponsor = new web3.Keypair();
 
   const [swapData] = web3.PublicKey.findProgramAddressSync(
-    [alice.publicKey.toBuffer(), secretHash],
+    [
+      alice.publicKey.toBuffer(),
+      bob.publicKey.toBuffer(),
+      secretHash,
+      swapAmount.toArrayLike(Buffer, "le", 8),
+      timelock.toArrayLike(Buffer, "le", 8),
+    ],
     program.programId
   );
   const [tokenVault] = web3.PublicKey.findProgramAddressSync(

--- a/tests/solana-spl-swaps.ts
+++ b/tests/solana-spl-swaps.ts
@@ -18,7 +18,7 @@ const program = workspace.SolanaSplSwaps as Program<SolanaSplSwaps>;
 
 describe("Testing one way swap between Alice and Bob", () => {
   const swapAmount = new BN(10);
-  const swapExpiresIn = new BN(2); // 2 slots = 800 ms
+  const timelock = new BN(2); // 2 slots = 800 ms
   const secret: Buffer = crypto.randomBytes(32);
   const secretHash: Buffer = crypto
     .createHash("sha256")
@@ -110,10 +110,10 @@ Sponsor   : ${rentSponsor.publicKey}\n`
   async function aliceInitiate() {
     const signature = await program.methods
       .initiate(
-        swapExpiresIn,
         bob.publicKey,
         [...secretHash],
         swapAmount,
+        timelock,
         destinationData
       )
       .accounts({
@@ -164,9 +164,9 @@ Sponsor   : ${rentSponsor.publicKey}\n`
 
   it("Test refund", async () => {
     await aliceInitiate(); // Re-initiating for this test
-    const expiryMs = swapExpiresIn.toNumber() * 400;
-    console.log(`Awaiting timelock of ${expiryMs}ms for Refund`);
-    await new Promise((r) => setTimeout(r, expiryMs + 1000)); // Add an extra sec
+    const timelockMs = timelock.toNumber() * 400;
+    console.log(`Awaiting timelock of ${timelockMs}ms for Refund`);
+    await new Promise((r) => setTimeout(r, timelockMs + 1000)); // Add an extra sec
     const aliceBalanceBefore = (
       await connection.getTokenAccountBalance(aliceTokenAccount)
     ).value.uiAmount;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,36 +9,34 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@coral-xyz/anchor-errors@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz"
-  integrity sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==
+"@coral-xyz/anchor-errors@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz#d635cbac2533973ae6bfb5d3ba1de89ce5aece2d"
+  integrity sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==
 
-"@coral-xyz/anchor@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.30.1.tgz"
-  integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
+"@coral-xyz/anchor@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.31.1.tgz#0fdeebf45a3cb2e47e8ebbb815ca98542152962c"
+  integrity sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA==
   dependencies:
-    "@coral-xyz/anchor-errors" "^0.30.1"
-    "@coral-xyz/borsh" "^0.30.1"
+    "@coral-xyz/anchor-errors" "^0.31.1"
+    "@coral-xyz/borsh" "^0.31.1"
     "@noble/hashes" "^1.3.1"
-    "@solana/web3.js" "^1.68.0"
+    "@solana/web3.js" "^1.69.0"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
     buffer-layout "^1.2.2"
     camelcase "^6.3.0"
     cross-fetch "^3.1.5"
-    crypto-hash "^1.3.0"
     eventemitter3 "^4.0.7"
     pako "^2.0.3"
-    snake-case "^3.0.4"
     superstruct "^0.15.4"
     toml "^3.0.0"
 
-"@coral-xyz/borsh@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.30.1.tgz"
-  integrity sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==
+"@coral-xyz/borsh@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.31.1.tgz#5328e1e0921b75d7f4a62dd3f61885a938bc7241"
+  integrity sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==
   dependencies:
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
@@ -50,7 +48,7 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
-"@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@1.5.0":
+"@noble/hashes@1.5.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
@@ -72,13 +70,6 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/codecs-core@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-preview.4.tgz"
-  integrity sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==
-  dependencies:
-    "@solana/errors" "2.0.0-preview.4"
-
 "@solana/codecs-core@2.0.0-rc.1":
   version "2.0.0-rc.1"
   resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz"
@@ -86,14 +77,12 @@
   dependencies:
     "@solana/errors" "2.0.0-rc.1"
 
-"@solana/codecs-data-structures@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.4.tgz"
-  integrity sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==
+"@solana/codecs-core@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-core/-/codecs-core-2.3.0.tgz#6bf2bb565cb1ae880f8018635c92f751465d8695"
+  integrity sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==
   dependencies:
-    "@solana/codecs-core" "2.0.0-preview.4"
-    "@solana/codecs-numbers" "2.0.0-preview.4"
-    "@solana/errors" "2.0.0-preview.4"
+    "@solana/errors" "2.3.0"
 
 "@solana/codecs-data-structures@2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -104,14 +93,6 @@
     "@solana/codecs-numbers" "2.0.0-rc.1"
     "@solana/errors" "2.0.0-rc.1"
 
-"@solana/codecs-numbers@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.4.tgz"
-  integrity sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==
-  dependencies:
-    "@solana/codecs-core" "2.0.0-preview.4"
-    "@solana/errors" "2.0.0-preview.4"
-
 "@solana/codecs-numbers@2.0.0-rc.1":
   version "2.0.0-rc.1"
   resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz"
@@ -120,14 +101,13 @@
     "@solana/codecs-core" "2.0.0-rc.1"
     "@solana/errors" "2.0.0-rc.1"
 
-"@solana/codecs-strings@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-preview.4.tgz"
-  integrity sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==
+"@solana/codecs-numbers@^2.1.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz#ac7e7f38aaf7fcd22ce2061fbdcd625e73828dc6"
+  integrity sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==
   dependencies:
-    "@solana/codecs-core" "2.0.0-preview.4"
-    "@solana/codecs-numbers" "2.0.0-preview.4"
-    "@solana/errors" "2.0.0-preview.4"
+    "@solana/codecs-core" "2.3.0"
+    "@solana/errors" "2.3.0"
 
 "@solana/codecs-strings@2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -137,17 +117,6 @@
     "@solana/codecs-core" "2.0.0-rc.1"
     "@solana/codecs-numbers" "2.0.0-rc.1"
     "@solana/errors" "2.0.0-rc.1"
-
-"@solana/codecs@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-preview.4.tgz"
-  integrity sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==
-  dependencies:
-    "@solana/codecs-core" "2.0.0-preview.4"
-    "@solana/codecs-data-structures" "2.0.0-preview.4"
-    "@solana/codecs-numbers" "2.0.0-preview.4"
-    "@solana/codecs-strings" "2.0.0-preview.4"
-    "@solana/options" "2.0.0-preview.4"
 
 "@solana/codecs@2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -160,14 +129,6 @@
     "@solana/codecs-strings" "2.0.0-rc.1"
     "@solana/options" "2.0.0-rc.1"
 
-"@solana/errors@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-preview.4.tgz"
-  integrity sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==
-  dependencies:
-    chalk "^5.3.0"
-    commander "^12.1.0"
-
 "@solana/errors@2.0.0-rc.1":
   version "2.0.0-rc.1"
   resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz"
@@ -176,16 +137,13 @@
     chalk "^5.3.0"
     commander "^12.1.0"
 
-"@solana/options@2.0.0-preview.4":
-  version "2.0.0-preview.4"
-  resolved "https://registry.npmjs.org/@solana/options/-/options-2.0.0-preview.4.tgz"
-  integrity sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==
+"@solana/errors@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@solana/errors/-/errors-2.3.0.tgz#4ac9380343dbeffb9dffbcb77c28d0e457c5fa31"
+  integrity sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==
   dependencies:
-    "@solana/codecs-core" "2.0.0-preview.4"
-    "@solana/codecs-data-structures" "2.0.0-preview.4"
-    "@solana/codecs-numbers" "2.0.0-preview.4"
-    "@solana/codecs-strings" "2.0.0-preview.4"
-    "@solana/errors" "2.0.0-preview.4"
+    chalk "^5.4.1"
+    commander "^14.0.0"
 
 "@solana/options@2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -198,41 +156,32 @@
     "@solana/codecs-strings" "2.0.0-rc.1"
     "@solana/errors" "2.0.0-rc.1"
 
-"@solana/spl-token-group@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.5.tgz"
-  integrity sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==
-  dependencies:
-    "@solana/codecs" "2.0.0-preview.4"
-    "@solana/spl-type-length-value" "0.1.0"
-
-"@solana/spl-token-metadata@^0.1.3":
-  version "0.1.5"
-  resolved "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.5.tgz"
-  integrity sha512-DSBlo7vjuLe/xvNn75OKKndDBkFxlqjLdWlq6rf40StnrhRn7TDntHGLZpry1cf3uzQFShqeLROGNPAJwvkPnA==
+"@solana/spl-token-group@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz#83c00f0cd0bda33115468cd28b89d94f8ec1fee4"
+  integrity sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
-    "@solana/spl-type-length-value" "0.1.0"
 
-"@solana/spl-token@^0.4.8":
-  version "0.4.8"
-  resolved "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.8.tgz"
-  integrity sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==
+"@solana/spl-token-metadata@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz#d240947aed6e7318d637238022a7b0981b32ae80"
+  integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.13.tgz#8f65c3c2b315e1a00a91b8d0f60922c6eb71de62"
+  integrity sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==
   dependencies:
     "@solana/buffer-layout" "^4.0.0"
     "@solana/buffer-layout-utils" "^0.2.0"
-    "@solana/spl-token-group" "^0.0.5"
-    "@solana/spl-token-metadata" "^0.1.3"
+    "@solana/spl-token-group" "^0.0.7"
+    "@solana/spl-token-metadata" "^0.1.6"
     buffer "^6.0.3"
 
-"@solana/spl-type-length-value@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz"
-  integrity sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==
-  dependencies:
-    buffer "^6.0.3"
-
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.94.0", "@solana/web3.js@^1.95.3":
+"@solana/web3.js@^1.32.0":
   version "1.95.3"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.3.tgz"
   integrity sha512-O6rPUN0w2fkNqx/Z3QJMB9L225Ex10PRDH8bTaIUPZXMPV0QP8ZpPvjQnXK+upUczlRgzHzd6SjKIha1p+I6og==
@@ -243,6 +192,27 @@
     "@solana/buffer-layout" "^4.0.1"
     agentkeepalive "^4.5.0"
     bigint-buffer "^1.1.5"
+    bn.js "^5.2.1"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.1.1"
+    node-fetch "^2.7.0"
+    rpc-websockets "^9.0.2"
+    superstruct "^2.0.2"
+
+"@solana/web3.js@^1.69.0":
+  version "1.98.4"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.98.4.tgz#df51d78be9d865181ec5138b4e699d48e6895bbe"
+  integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    "@noble/curves" "^1.4.2"
+    "@noble/hashes" "^1.4.0"
+    "@solana/buffer-layout" "^4.0.1"
+    "@solana/codecs-numbers" "^2.1.0"
+    agentkeepalive "^4.5.0"
     bn.js "^5.2.1"
     borsh "^0.7.0"
     bs58 "^4.0.1"
@@ -324,6 +294,14 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 agentkeepalive@^4.5.0:
   version "4.5.0"
@@ -464,7 +442,7 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
 
-buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -509,6 +487,11 @@ chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
+chalk@^5.4.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.0.tgz#a1a8d294ea3526dbb77660f12649a08490e33ab8"
+  integrity sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==
 
 check-error@^1.0.3:
   version "1.0.3"
@@ -558,6 +541,11 @@ commander@^12.1.0:
   resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
+commander@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.0.tgz#f244fc74a92343514e56229f16ef5c5e22ced5e9"
+  integrity sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==
+
 commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
@@ -574,11 +562,6 @@ cross-fetch@^3.1.5:
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
   dependencies:
     node-fetch "^2.6.12"
-
-crypto-hash@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz"
-  integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
 
 debug@4.3.3:
   version "4.3.3"
@@ -604,23 +587,15 @@ delay@^5.0.0:
   resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
   integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
-diff@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -669,11 +644,6 @@ fast-stable-stringify@^1.0.0:
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
 
-fastestsmallesttextencoderdecoder@^1.0.22:
-  version "1.0.22"
-  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
-  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
@@ -703,6 +673,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -830,13 +805,13 @@ jayson@^4.1.1:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
-    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.5.10"
 
@@ -864,14 +839,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
@@ -894,29 +861,22 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
-  dependencies:
-    tslib "^2.0.3"
-
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
   integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -932,7 +892,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-"mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X", mocha@^9.0.3:
+mocha@^9.0.3:
   version "9.2.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz"
   integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
@@ -962,28 +922,20 @@ mkdirp@^0.5.1:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-ms@^2.0.0, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@2.1.3, ms@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 nanoid@3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
-
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
 
 node-fetch@^2.6.12, node-fetch@^2.7.0:
   version "2.7.0"
@@ -1105,14 +1057,6 @@ serialize-javascript@6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-snake-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz"
-  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
-
 source-map-support@^0.5.6:
   version "0.5.21"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
@@ -1162,17 +1106,17 @@ superstruct@^2.0.2:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz"
   integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1236,7 +1180,7 @@ tsconfig-paths@^3.5.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.3, tslib@^2.4.0:
+tslib@^2.4.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz"
   integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
@@ -1251,17 +1195,12 @@ typescript@^4.3.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@>=5:
-  version "5.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz"
-  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
-
 undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
+utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1312,7 +1251,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^7.5.10:
+ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
@@ -1327,15 +1266,15 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Solana UDAs  
Added Solana UDA logic directly to the HTLC program. Two functions to focus on -  
- `create_uda_spl`: Function to create a UDA PDA which stores all swap data and creates an ephemeral token vault which acts as the unique address user will send funds to.  
- `initiate_uda`: Function to check whether the UDA has enough balance and to initiate a swap. Instead of calling the initiate function, it mirrors the actions of it.  